### PR TITLE
5 Add stopper channel to stop consuming on a consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,13 @@ below).
 There are some features and aspects not properly documented yet. I will quickly
 list those here, hopefully they will be expanded in the future. :wink:
 
+- Stop consuming: Use the `stopper` channel returned from `queue.AddConsumer`
+  to stop consuming on this consumer:
+    ```go
+    name, stopper := queue.AddConsumer("task consumer", taskConsumer)
+    stopper <- 1 // now taskConsumer.Consume() won't be called anymore
+    ```
+
 - Batch Consumers: Use `queue.AddBatchConsumer()` to register a consumer that
   receives batches of deliveries to be consumed at once (database bulk insert)
 - Push Queues: When consuming queue A you can set up its push queue to be queue

--- a/consumer_context.go
+++ b/consumer_context.go
@@ -1,0 +1,11 @@
+package rmq
+
+type ConsumerContext struct {
+	StopChan chan int
+}
+
+func NewConsumerContext() *ConsumerContext {
+	return &ConsumerContext{
+		StopChan: make(chan int, 1),
+	}
+}

--- a/consumer_context.go
+++ b/consumer_context.go
@@ -1,11 +1,22 @@
 package rmq
 
+import "sync"
+
 type ConsumerContext struct {
-	StopChan chan int
+	stopChan chan int
+	wg       *sync.WaitGroup
 }
 
 func NewConsumerContext() *ConsumerContext {
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
 	return &ConsumerContext{
-		StopChan: make(chan int, 1),
+		stopChan: make(chan int, 1),
+		wg:       wg,
 	}
+}
+
+func (context *ConsumerContext) StopConsuming() *sync.WaitGroup {
+	context.stopChan <- 1
+	return context.wg
 }

--- a/queue.go
+++ b/queue.go
@@ -351,12 +351,13 @@ func (queue *redisQueue) consumeBatch(batchSize int) bool {
 func (queue *redisQueue) consumerConsume(consumer Consumer, context *ConsumerContext) {
 	for {
 		select {
+		case <-context.stopChan:
+			// debug(fmt.Sprintf("consumer stopped %s", consumer)) // COMMENTOUT
+			context.wg.Done()
+			return
 		case delivery := <-queue.deliveryChan:
 			// debug(fmt.Sprintf("consumer consume %s %s", delivery, consumer)) // COMMENTOUT
 			consumer.Consume(delivery)
-		case <-context.StopChan:
-			// debug(fmt.Sprintf("consumer stopped %s", consumer)) // COMMENTOUT
-			return
 		}
 	}
 }

--- a/queue_test.go
+++ b/queue_test.go
@@ -247,14 +247,14 @@ func (suite *QueueSuite) TestStop(c *C) {
 	consumer := NewTestConsumer("stop-cons")
 
 	queue.StartConsuming(10, time.Millisecond)
-	_, stopper := queue.AddConsumer("stop-cons", consumer)
+	_, context := queue.AddConsumer("stop-cons", consumer)
 
 	c.Check(queue.Publish("stop-d1"), Equals, true)
 	time.Sleep(2 * time.Millisecond)
 	c.Check(consumer.LastDeliveries, HasLen, 1)
 	c.Check(consumer.LastDelivery.Payload(), Equals, "stop-d1")
 
-	stopper <- 1
+	context.StopChan <- 1
 
 	c.Check(queue.Publish("stop-d2"), Equals, true)
 	time.Sleep(2 * time.Millisecond)

--- a/queue_test.go
+++ b/queue_test.go
@@ -254,7 +254,7 @@ func (suite *QueueSuite) TestStop(c *C) {
 	c.Check(consumer.LastDeliveries, HasLen, 1)
 	c.Check(consumer.LastDelivery.Payload(), Equals, "stop-d1")
 
-	context.StopChan <- 1
+	context.StopConsuming()
 
 	c.Check(queue.Publish("stop-d2"), Equals, true)
 	time.Sleep(2 * time.Millisecond)

--- a/test_queue.go
+++ b/test_queue.go
@@ -37,7 +37,7 @@ func (queue *TestQueue) StopConsuming() bool {
 	return true
 }
 
-func (queue *TestQueue) AddConsumer(tag string, consumer Consumer) (name string, stopper chan<- int) {
+func (queue *TestQueue) AddConsumer(tag string, consumer Consumer) (name string, context *ConsumerContext) {
 	return "", nil
 }
 

--- a/test_queue.go
+++ b/test_queue.go
@@ -37,8 +37,8 @@ func (queue *TestQueue) StopConsuming() bool {
 	return true
 }
 
-func (queue *TestQueue) AddConsumer(tag string, consumer Consumer) string {
-	return ""
+func (queue *TestQueue) AddConsumer(tag string, consumer Consumer) (name string, stopper chan<- int) {
+	return "", nil
 }
 
 func (queue *TestQueue) AddBatchConsumer(tag string, batchSize int, consumer BatchConsumer) string {


### PR DESCRIPTION
Inspired by #5 

@ympons: I took the mechanics from [your fork](https://github.com/adjust/rmq/compare/master...Spatially:master), but implemented it slightly differently:

Instead of adding a new interface, I just added a return value `stopper chan bool` to the `Queue.AddConsumer` function. At any later time you can then stop consuming on this consumer by sending a value to the stopper channel:

``` go
name, stopper := queue.AddConsumer("task consumer", taskConsumer)
stopper <- 1 // now taskConsumer.Consume() won't be called anymore
```

Please let me know if this works for you!
