### PR TITLE
Adds helper function for conn keepalive

### DIFF
--- a/cleaner.go
+++ b/cleaner.go
@@ -1,6 +1,7 @@
 package rmq
 
 import "fmt"
+import "time"
 
 type Cleaner struct {
 	connection *redisConnection
@@ -24,6 +25,12 @@ func (cleaner *Cleaner) Clean() error {
 	}
 
 	return nil
+}
+
+func (cleaner *Cleaner) KeepConnectionAlive(interval time.Duration) {
+	for _ = range time.Tick(interval) {
+		cleaner.Clean()
+	}
 }
 
 func (cleaner *Cleaner) CleanConnection(connection *redisConnection) error {

--- a/example/cleaner.go
+++ b/example/cleaner.go
@@ -10,7 +10,7 @@ func main() {
 	connection := rmq.OpenConnection("cleaner", "tcp", "localhost:6379", 2)
 	cleaner := rmq.NewCleaner(connection)
 
-	for _ = range time.Tick(time.Second) {
-		cleaner.Clean()
-	}
+	// Every five seconds, clean the connection.
+	cleaner.KeepConnectionAlive(5 * time.Second)
+
 }


### PR DESCRIPTION
cleaner.KeepConnectionAlive is a useful helper function, particularly if you run it in a goroutine upon instantiation of a connection.
