### PR TITLE
Add timeout for batch consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ list those here, hopefully they will be expanded in the future. :wink:
 
 - Batch Consumers: Use `queue.AddBatchConsumer()` to register a consumer that
   receives batches of deliveries to be consumed at once (database bulk insert)
+  See [`example/batch_consumer.go`][batch_consumer.go]
 - Push Queues: When consuming queue A you can set up its push queue to be queue
   B. The consumer can then call `delivery.Push()` to push this delivery
   (originally from queue A) to the associated push queue B. (useful for
@@ -282,6 +283,7 @@ list those here, hopefully they will be expanded in the future. :wink:
   There's also `queue.PurgeReady` if you want to get a queue clean without
   consuming possibly bad deliveries. See [`example/purger.go`][purger.go]
 
+[batch_consumer.go]: example/batch_consumer.go
 [cleaner.go]: example/cleaner.go
 [returner.go]: example/returner.go
 [purger.go]: example/purger.go

--- a/example/batch_consumer.go
+++ b/example/batch_consumer.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"log"
+	"time"
+
+	"github.com/adjust/rmq"
+)
+
+const unackedLimit = 1000
+
+func main() {
+	connection := rmq.OpenConnection("consumer", "tcp", "localhost:6379", 2)
+	queue := connection.OpenQueue("things")
+	queue.StartConsuming(unackedLimit, 500*time.Millisecond)
+	queue.AddBatchConsumer("batch", 111, NewBatchConsumer())
+	select {}
+}
+
+type BatchConsumer struct {
+}
+
+func NewBatchConsumer() *BatchConsumer {
+	return &BatchConsumer{}
+}
+
+func (consumer *BatchConsumer) Consume(batch rmq.Deliveries) {
+	time.Sleep(time.Millisecond)
+	log.Printf("consumed %d", len(batch))
+	batch.Ack()
+}

--- a/queue.go
+++ b/queue.go
@@ -397,7 +397,9 @@ func (queue *redisQueue) consumerBatchConsume(batchSize int, timeout time.Durati
 
 		// reset batch and timer
 		batch = batch[:0]
-		timer.Stop()
+		if !timer.Stop() {
+			<-timer.C
+		}
 	}
 }
 

--- a/queue_test.go
+++ b/queue_test.go
@@ -254,7 +254,7 @@ func (suite *QueueSuite) TestBatch(c *C) {
 	c.Check(queue.UnackedCount(), Equals, 5)
 
 	consumer := NewTestBatchConsumer()
-	queue.AddBatchConsumer("batch-cons", 2, consumer)
+	queue.AddBatchConsumerWithTimeout("batch-cons", 2, 10*time.Millisecond, consumer)
 	time.Sleep(2 * time.Millisecond)
 	c.Assert(consumer.LastBatch, HasLen, 2)
 	c.Check(consumer.LastBatch[0].Payload(), Equals, "batch-d0")
@@ -280,7 +280,7 @@ func (suite *QueueSuite) TestBatch(c *C) {
 	c.Check(queue.UnackedCount(), Equals, 1)
 	c.Check(queue.RejectedCount(), Equals, 2)
 
-	time.Sleep(time.Second)
+	time.Sleep(15 * time.Millisecond)
 	c.Assert(consumer.LastBatch, HasLen, 1)
 	c.Check(consumer.LastBatch[0].Payload(), Equals, "batch-d4")
 	c.Check(consumer.LastBatch[0].Reject(), Equals, true)

--- a/queue_test.go
+++ b/queue_test.go
@@ -280,13 +280,10 @@ func (suite *QueueSuite) TestBatch(c *C) {
 	c.Check(queue.UnackedCount(), Equals, 1)
 	c.Check(queue.RejectedCount(), Equals, 2)
 
-	c.Check(queue.Publish("batch-d5"), Equals, true)
-	time.Sleep(2 * time.Millisecond)
-	c.Assert(consumer.LastBatch, HasLen, 2)
+	time.Sleep(time.Second)
+	c.Assert(consumer.LastBatch, HasLen, 1)
 	c.Check(consumer.LastBatch[0].Payload(), Equals, "batch-d4")
-	c.Check(consumer.LastBatch[1].Payload(), Equals, "batch-d5")
 	c.Check(consumer.LastBatch[0].Reject(), Equals, true)
-	c.Check(consumer.LastBatch[1].Ack(), Equals, true)
 	c.Check(queue.UnackedCount(), Equals, 0)
 	c.Check(queue.RejectedCount(), Equals, 3)
 }

--- a/test_queue.go
+++ b/test_queue.go
@@ -45,6 +45,10 @@ func (queue *TestQueue) AddBatchConsumer(tag string, batchSize int, consumer Bat
 	return ""
 }
 
+func (queue *TestQueue) AddBatchConsumerWithTimeout(tag string, batchSize int, timeout time.Duration, consumer BatchConsumer) string {
+	return ""
+}
+
 func (queue *TestQueue) ReturnRejected(count int) int {
 	return 0
 }


### PR DESCRIPTION
Currently a batch consumer only gets batches when they are finished. A batch is checked to be finished only when new deliveries are published to the queue. That means when a producer goes down, the batch consumer might not consume the last deliveries because the current batch never gets triggered to check if it's complete.

This PR adds a timeout for batch consumers which is one second by default. You can use a different timeout by using `Queue.AddBatchConsumerWithTimeout()`.