### PR TITLE
Purge lists in a non blocking way

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -37,8 +37,8 @@ type Queue interface {
 	AddConsumer(tag string, consumer Consumer) string
 	AddBatchConsumer(tag string, batchSize int, consumer BatchConsumer) string
 	AddBatchConsumerWithTimeout(tag string, batchSize int, timeout time.Duration, consumer BatchConsumer) string
-	PurgeReady() bool
-	PurgeRejected() bool
+	PurgeReady() int
+	PurgeRejected() int
 	ReturnRejected(count int) int
 	ReturnAllRejected() int
 	Close() bool
@@ -99,13 +99,13 @@ func (queue *redisQueue) PublishBytes(payload []byte) bool {
 }
 
 // PurgeReady removes all ready deliveries from the queue and returns the number of purged deliveries
-func (queue *redisQueue) PurgeReady() bool {
-	return queue.deleteRedisList(queue.readyKey) > 0
+func (queue *redisQueue) PurgeReady() int {
+	return queue.deleteRedisList(queue.readyKey)
 }
 
 // PurgeRejected removes all rejected deliveries from the queue and returns the number of purged deliveries
-func (queue *redisQueue) PurgeRejected() bool {
-	return queue.deleteRedisList(queue.rejectedKey) > 0
+func (queue *redisQueue) PurgeRejected() int {
+	return queue.deleteRedisList(queue.rejectedKey)
 }
 
 // Close purges and removes the queue from the list of queues

--- a/queue_test.go
+++ b/queue_test.go
@@ -98,7 +98,7 @@ func (suite *QueueSuite) TestQueue(c *C) {
 	c.Check(queue.ReadyCount(), Equals, 1)
 	c.Check(queue.Publish("queue-d2"), Equals, true)
 	c.Check(queue.ReadyCount(), Equals, 2)
-	c.Check(queue.PurgeReady(), Equals, 1)
+	c.Check(queue.PurgeReady(), Equals, 2)
 	c.Check(queue.ReadyCount(), Equals, 0)
 	c.Check(queue.PurgeReady(), Equals, 0)
 
@@ -181,8 +181,7 @@ func (suite *QueueSuite) TestConsumer(c *C) {
 	c.Check(queue.ReadyCount(), Equals, 0)
 	c.Check(queue.UnackedCount(), Equals, 0)
 	c.Check(queue.RejectedCount(), Equals, 2)
-
-	c.Check(queue.PurgeRejected(), Equals, 1)
+	c.Check(queue.PurgeRejected(), Equals, 2)
 	c.Check(queue.RejectedCount(), Equals, 0)
 	c.Check(queue.PurgeRejected(), Equals, 0)
 

--- a/queue_test.go
+++ b/queue_test.go
@@ -98,9 +98,9 @@ func (suite *QueueSuite) TestQueue(c *C) {
 	c.Check(queue.ReadyCount(), Equals, 1)
 	c.Check(queue.Publish("queue-d2"), Equals, true)
 	c.Check(queue.ReadyCount(), Equals, 2)
-	c.Check(queue.PurgeReady(), Equals, true)
+	c.Check(queue.PurgeReady(), Equals, 1)
 	c.Check(queue.ReadyCount(), Equals, 0)
-	c.Check(queue.PurgeReady(), Equals, false)
+	c.Check(queue.PurgeReady(), Equals, 0)
 
 	queue.RemoveAllConsumers()
 	c.Check(queue.GetConsumers(), HasLen, 0)
@@ -182,9 +182,9 @@ func (suite *QueueSuite) TestConsumer(c *C) {
 	c.Check(queue.UnackedCount(), Equals, 0)
 	c.Check(queue.RejectedCount(), Equals, 2)
 
-	c.Check(queue.PurgeRejected(), Equals, true)
+	c.Check(queue.PurgeRejected(), Equals, 1)
 	c.Check(queue.RejectedCount(), Equals, 0)
-	c.Check(queue.PurgeRejected(), Equals, false)
+	c.Check(queue.PurgeRejected(), Equals, 0)
 
 	queue.StopConsuming()
 	connection.StopHeartbeat()

--- a/test_queue.go
+++ b/test_queue.go
@@ -57,12 +57,12 @@ func (queue *TestQueue) ReturnAllRejected() int {
 	return 0
 }
 
-func (queue *TestQueue) PurgeReady() bool {
-	return false
+func (queue *TestQueue) PurgeReady() int {
+	return 0
 }
 
-func (queue *TestQueue) PurgeRejected() bool {
-	return false
+func (queue *TestQueue) PurgeRejected() int {
+	return 0
 }
 
 func (queue *TestQueue) Close() bool {


### PR DESCRIPTION
Currently `PurgeReady()` and `PurgeRejected()` use `DEL` to delete a Redis list. This can take a bit of time on long lists, in which Redis might become unresponsive.
https://redis.io/commands/del

This PR tries to improve that by emptying the list by removing items in smaller chunks, similar to this strategy: https://www.redisgreen.net/blog/deleting-large-lists/

Please note that this change is breaking if you're using the return value of the purge functions. They used to return a bool indicating whether or not anything was purged. They now return the number of purged deliveries. So if you're affected by that you might need to change your checks from
```go
if queue.PurgeRejected() { ... }
```
to:
```go
if queue.PurgeRejected() > 0 { ... }
```