### PR TITLE
Graceful stop consuming

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,31 @@ For a full example see [`example/consumer`][consumer.go]
 
 [consumer.go]: example/consumer/main.go
 
+### Stop Consuming
+
+If you want to stop consuming from the queue, you can call `StopConsuming`:
+
+```go
+finishedChan := taskQueue.StopConsuming()
+```
+
+When `StopConsuming` is called, it will continue fetching its current batch of
+deliveries. After that the consumers continue to consume the fetched deliveries
+until all unacked deliveries are fully consumed. If `StopConsuming` is called
+before consuming or after already stopped, it will return a closed channel. If
+you want to wait until all consumers are idle you can wait on the `finishedChan`:
+
+```go
+  <-finishedChan
+```
+
+This is useful to implement a graceful shutdown of a consumer service. Please
+note that after calling `StopConsuming` the queue might not be in a state where
+you can add consumers and call `StartConsuming` again. If you have a use case
+where you actually need that sort of flexibility, please let us know. Currently
+for each queue you are only supposed to call `StartConsuming` and
+`StopConsuming` at most once.
+
 ## Testing Included
 
 To simplify testing of queue producers and consumers we include test mocks.

--- a/cleaner_test.go
+++ b/cleaner_test.go
@@ -50,19 +50,19 @@ func (suite *CleanerSuite) TestCleaner(c *C) {
 	consumer.AutoAck = false
 
 	queue.AddConsumer("consumer1", consumer)
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	c.Check(queue.UnackedCount(), Equals, 3)
 	c.Check(queue.ReadyCount(), Equals, 3)
 
 	c.Assert(consumer.LastDelivery, NotNil)
 	c.Check(consumer.LastDelivery.Payload(), Equals, "del1")
 	c.Check(consumer.LastDelivery.Ack(), Equals, true)
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	c.Check(queue.UnackedCount(), Equals, 2)
 	c.Check(queue.ReadyCount(), Equals, 3)
 
 	consumer.Finish()
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	c.Check(queue.UnackedCount(), Equals, 3)
 	c.Check(queue.ReadyCount(), Equals, 2)
 	c.Check(consumer.LastDelivery.Payload(), Equals, "del2")
@@ -96,19 +96,19 @@ func (suite *CleanerSuite) TestCleaner(c *C) {
 	consumer.AutoAck = false
 
 	queue.AddConsumer("consumer2", consumer)
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	c.Check(queue.UnackedCount(), Equals, 3)
 	c.Check(queue.ReadyCount(), Equals, 4)
 	c.Check(consumer.LastDelivery.Payload(), Equals, "del5")
 
 	consumer.Finish() // unacked
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	c.Check(queue.UnackedCount(), Equals, 4)
 	c.Check(queue.ReadyCount(), Equals, 3)
 
 	c.Check(consumer.LastDelivery.Payload(), Equals, "del6")
 	c.Check(consumer.LastDelivery.Ack(), Equals, true)
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	c.Check(queue.UnackedCount(), Equals, 3)
 	c.Check(queue.ReadyCount(), Equals, 3)
 

--- a/queue.go
+++ b/queue.go
@@ -224,12 +224,15 @@ func (queue *redisQueue) StopConsuming() <-chan struct{} {
 		return nil // not consuming or already stopped
 	}
 
+	// log.Printf("rmq queue stopping %s", queue)
 	atomic.StoreInt32(&queue.consumingStopped, 1)
 	finishedChan := make(chan struct{})
 	go func() {
 		queue.stopWg.Wait()
 		close(finishedChan)
+		// log.Printf("rmq queue stopped consuming %s", queue)
 	}()
+
 	return finishedChan
 }
 
@@ -302,6 +305,7 @@ func (queue *redisQueue) consume() {
 		if atomic.LoadInt32(&queue.consumingStopped) == int32(1) {
 			// log.Printf("rmq queue stopped consuming %s", queue)
 			close(queue.deliveryChan)
+			// log.Printf("rmq queue stopped fetching %s", queue)
 			return
 		}
 	}

--- a/queue.go
+++ b/queue.go
@@ -249,6 +249,7 @@ func (queue *redisQueue) AddBatchConsumer(tag string, batchSize int, consumer Ba
 // Timeout limits the amount of time waiting to fill an entire batch
 // The timer is only started when the first message in a batch is received
 func (queue *redisQueue) AddBatchConsumerWithTimeout(tag string, batchSize int, timeout time.Duration, consumer BatchConsumer) string {
+	queue.stopWg.Add(1)
 	name := queue.addConsumer(tag)
 	go queue.consumerBatchConsume(batchSize, timeout, consumer)
 	return name
@@ -341,6 +342,7 @@ func (queue *redisQueue) consumerConsume(consumer Consumer) {
 }
 
 func (queue *redisQueue) consumerBatchConsume(batchSize int, timeout time.Duration, consumer BatchConsumer) {
+	defer queue.stopWg.Done()
 	batch := []Delivery{}
 	for {
 		// Wait for first delivery

--- a/queue_test.go
+++ b/queue_test.go
@@ -398,11 +398,11 @@ func (suite *QueueSuite) TestConsuming(c *C) {
 	connection := OpenConnection("consume", "tcp", "localhost:6379", 1)
 	queue := connection.OpenQueue("consume-q").(*redisQueue)
 
-	c.Check(queue.StopConsuming(), Equals, false)
+	wg := queue.StopConsuming()
+	c.Check(wg, NotNil)
 
 	queue.StartConsuming(10, time.Millisecond)
-	c.Check(queue.StopConsuming(), Equals, true)
-	c.Check(queue.StopConsuming(), Equals, false)
+	c.Check(queue.StopConsuming(), NotNil)
 }
 
 func (suite *QueueSuite) TestStopConsuming(c *C) {
@@ -423,9 +423,10 @@ func (suite *QueueSuite) TestStopConsuming(c *C) {
 		queue.AddConsumer("consume", consumer)
 	}
 
-	c.Check(queue.StopConsuming(), Equals, true)
+	wg := queue.StopConsuming()
+	c.Assert(wg, NotNil)
 
-	queue.stopWg.Wait()
+	wg.Wait()
 
 	var consumedCount int
 	for i := 0; i < 10; i++ {

--- a/queue_test.go
+++ b/queue_test.go
@@ -229,27 +229,27 @@ func (suite *QueueSuite) TestMulti(c *C) {
 	consumer.AutoFinish = false
 
 	queue.AddConsumer("multi-cons", consumer)
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	c.Check(queue.ReadyCount(), Equals, 9)
 	c.Check(queue.UnackedCount(), Equals, 11)
 
 	c.Check(consumer.LastDelivery.Ack(), Equals, true)
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	c.Check(queue.ReadyCount(), Equals, 9)
 	c.Check(queue.UnackedCount(), Equals, 10)
 
 	consumer.Finish()
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	c.Check(queue.ReadyCount(), Equals, 8)
 	c.Check(queue.UnackedCount(), Equals, 11)
 
 	c.Check(consumer.LastDelivery.Ack(), Equals, true)
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	c.Check(queue.ReadyCount(), Equals, 8)
 	c.Check(queue.UnackedCount(), Equals, 10)
 
 	consumer.Finish()
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	c.Check(queue.ReadyCount(), Equals, 7)
 	c.Check(queue.UnackedCount(), Equals, 11)
 
@@ -268,12 +268,12 @@ func (suite *QueueSuite) TestBatch(c *C) {
 	}
 
 	queue.StartConsuming(10, time.Millisecond)
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	c.Check(queue.UnackedCount(), Equals, 5)
 
 	consumer := NewTestBatchConsumer()
-	queue.AddBatchConsumerWithTimeout("batch-cons", 2, 10*time.Millisecond, consumer)
-	time.Sleep(2 * time.Millisecond)
+	queue.AddBatchConsumerWithTimeout("batch-cons", 2, 50*time.Millisecond, consumer)
+	time.Sleep(10 * time.Millisecond)
 	c.Assert(consumer.LastBatch, HasLen, 2)
 	c.Check(consumer.LastBatch[0].Payload(), Equals, "batch-d0")
 	c.Check(consumer.LastBatch[1].Payload(), Equals, "batch-d1")
@@ -283,7 +283,7 @@ func (suite *QueueSuite) TestBatch(c *C) {
 	c.Check(queue.RejectedCount(), Equals, 1)
 
 	consumer.Finish()
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	c.Assert(consumer.LastBatch, HasLen, 2)
 	c.Check(consumer.LastBatch[0].Payload(), Equals, "batch-d2")
 	c.Check(consumer.LastBatch[1].Payload(), Equals, "batch-d3")
@@ -293,12 +293,12 @@ func (suite *QueueSuite) TestBatch(c *C) {
 	c.Check(queue.RejectedCount(), Equals, 2)
 
 	consumer.Finish()
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	c.Check(consumer.LastBatch, HasLen, 0)
 	c.Check(queue.UnackedCount(), Equals, 1)
 	c.Check(queue.RejectedCount(), Equals, 2)
 
-	time.Sleep(15 * time.Millisecond)
+	time.Sleep(60 * time.Millisecond)
 	c.Assert(consumer.LastBatch, HasLen, 1)
 	c.Check(consumer.LastBatch[0].Payload(), Equals, "batch-d4")
 	c.Check(consumer.LastBatch[0].Reject(), Equals, true)

--- a/test_batch_consumer.go
+++ b/test_batch_consumer.go
@@ -1,7 +1,9 @@
 package rmq
 
 type TestBatchConsumer struct {
-	LastBatch Deliveries
+	LastBatch     Deliveries
+	ConsumedCount int
+	AutoFinish    bool
 
 	finish chan int
 }
@@ -15,8 +17,11 @@ func NewTestBatchConsumer() *TestBatchConsumer {
 func (consumer *TestBatchConsumer) Consume(batch Deliveries) {
 	// log.Printf("TestBatchConsumer.Consume(%d)", len(batch))
 	consumer.LastBatch = batch
-	<-consumer.finish
-	// log.Printf("TestBatchConsumer.Consume() finished")
+	consumer.ConsumedCount += len(batch)
+	if !consumer.AutoFinish {
+		<-consumer.finish
+		// log.Printf("TestBatchConsumer.Consume() finished")
+	}
 }
 
 func (consumer *TestBatchConsumer) Finish() {

--- a/test_queue.go
+++ b/test_queue.go
@@ -1,6 +1,9 @@
 package rmq
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 type TestQueue struct {
 	name           string
@@ -33,8 +36,8 @@ func (queue *TestQueue) StartConsuming(prefetchLimit int, pollDuration time.Dura
 	return true
 }
 
-func (queue *TestQueue) StopConsuming() bool {
-	return true
+func (queue *TestQueue) StopConsuming() *sync.WaitGroup {
+	return nil
 }
 
 func (queue *TestQueue) AddConsumer(tag string, consumer Consumer) string {

--- a/test_queue.go
+++ b/test_queue.go
@@ -1,9 +1,6 @@
 package rmq
 
-import (
-	"sync"
-	"time"
-)
+import "time"
 
 type TestQueue struct {
 	name           string
@@ -36,7 +33,7 @@ func (queue *TestQueue) StartConsuming(prefetchLimit int, pollDuration time.Dura
 	return true
 }
 
-func (queue *TestQueue) StopConsuming() *sync.WaitGroup {
+func (queue *TestQueue) StopConsuming() <-chan struct{} {
 	return nil
 }
 


### PR DESCRIPTION
This PR closes `deliveryChan` when stop consuming and returns a channel.

the internal `WaitGroup` is increased when adding consumer and decreased when each consumer's consume loop ends. 

the caller can call
```go
finishedChan := queue.StopConsuming()
<- finishedChan
```

to make sure queue consuming is fully stopped.

## NOTE
this PR changes `StopConsuming` in interface `Queue` to return a channel