### PR TITLE
Allow cleaner to operate on `Connection` interface

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,17 +3,22 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:2da0a4c7b01fcbfcf0539f1f170aebaf25544f5b1bee67994bfde511f32fc45d"
   name = "github.com/adjust/gocheck"
   packages = ["."]
+  pruneopts = "UT"
   revision = "fbc315b36e0e7dc95023e96b43af5d8de58bc6fb"
 
 [[projects]]
   branch = "master"
+  digest = "1:074f1d9654933c470f7d3e84ab60f942e287895011d58d4d73a3275b9587e446"
   name = "github.com/adjust/uniuri"
   packages = ["."]
+  pruneopts = "UT"
   revision = "498743145e60c272b71d377c4e456335e4ef7524"
 
 [[projects]]
+  digest = "1:c950e574951c7199fb3d990d0e7a61996f40f8e646ba7cf8a557878d4c737f53"
   name = "github.com/go-redis/redis"
   packages = [
     ".",
@@ -22,15 +27,19 @@
     "internal/hashtag",
     "internal/pool",
     "internal/proto",
-    "internal/singleflight",
-    "internal/util"
+    "internal/util",
   ]
-  revision = "68362cfda1eeb3a69316e7bc00169a9a8de4823a"
-  version = "v6.9.2"
+  pruneopts = "UT"
+  revision = "75795aa4236dc7341eefac3bbe945e68c99ef9df"
+  version = "v6.15.3"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "21a1c706629f90470e3bf4a31f2881dc639fd43fd9eadb7a674e339afd950be8"
+  input-imports = [
+    "github.com/adjust/gocheck",
+    "github.com/adjust/uniuri",
+    "github.com/go-redis/redis",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
I have a type like:

```go
func New(conn rmq.Connection, app *pericyte.App, logger logrus.FieldLogger, options ...option) (*Workers, error) {
	wrk := &Workers{
		app:           app,
		queue:         conn.OpenQueue(WorkQueueName),
		dispatcher:    &DefaultDispatcher{App: app},
		newCommand:    command.Default,
		cleaner:       rmq.NewCleaner(conn),
		cleaningTimer: time.NewTicker(cleanerDuration),
		logger:        logger.WithFields(logrus.Fields{"scope": "workers.New()"}),
	}
	for _, opt := range options {
		opt(wrk)
	}
	return wrk, nil
}
```

Because `Cleaner` requires an unexported `redisConnection` it means that I can't just take a single `Connection` argument to my type (which manages the cleaner running on a schedule). This means the constructing type has to care about, at least, creating a cleaner which breaks encapsulation.

By passing `Connection` in I can keep most of the rmq concerns isolated and because rmq provides a mock for `Connection` I can pass that in.

This PR makes the case when `Connection` is not a `redisConnection` a no-op - as for tests.

The option would be to just make `redisConnection` an exported type. I feel like the issues like this are an indication that it might be a bit of a smell - if I can call the methods, why can't I hold a reference...? However this PR solves my issue.