### PR TITLE
Use a global variable to hold the panic handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,14 @@ connection := rmq.OpenConnection("my service", "unix", "/tmp/redis.sock", 1)
 ```
 
 Note: rmq panics on Redis connection errors. Your producers and consumers will
-crash if Redis goes down. Please let us know if you would see this handled
-differently.
+crash if Redis goes down. However you can override this behaviour by setting
+`Panicf` to a different handler:
+
+```go
+rmq.Panicf = func(format string, v... interface{}) {
+	// Handle otherwise fatal errors with custom recovery logic
+}
+```
 
 ### Queue
 

--- a/connection.go
+++ b/connection.go
@@ -2,7 +2,6 @@ package rmq
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -51,7 +50,7 @@ func openConnectionWithRedisClient(tag string, redisClient RedisClient) *redisCo
 	}
 
 	if !connection.updateHeartbeat() { // checks the connection
-		log.Panicf("rmq connection failed to update heartbeat %s", connection)
+		Panicf("rmq connection failed to update heartbeat %s", connection)
 	}
 
 	// add to connection set after setting heartbeat to avoid race with cleaner

--- a/panic_handler.go
+++ b/panic_handler.go
@@ -1,0 +1,10 @@
+package rmq
+
+import "log"
+
+// By default rmq panics on various redis issues preferring to restart consumers and producers.
+// However if this behaviour is not desired you can override this handler. Beware that rmq
+// may be in an unusable state if sufficient recovery is not performed.
+var Panicf = func(format string, v ...interface{}) {
+	log.Panicf(format, v...)
+}

--- a/queue.go
+++ b/queue.go
@@ -2,7 +2,6 @@ package rmq
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -207,7 +206,7 @@ func (queue *redisQueue) StartConsuming(prefetchLimit int, pollDuration time.Dur
 
 	// add queue to list of queues consumed on this connection
 	if ok := queue.redisClient.SAdd(queue.queuesKey, queue.name); !ok {
-		log.Panicf("rmq queue failed to start consuming %s", queue)
+		Panicf("rmq queue failed to start consuming %s", queue)
 	}
 
 	queue.prefetchLimit = prefetchLimit
@@ -275,14 +274,14 @@ func (queue *redisQueue) RemoveConsumer(name string) bool {
 
 func (queue *redisQueue) addConsumer(tag string) string {
 	if queue.deliveryChan == nil {
-		log.Panicf("rmq queue failed to add consumer, call StartConsuming first! %s", queue)
+		Panicf("rmq queue failed to add consumer, call StartConsuming first! %s", queue)
 	}
 
 	name := fmt.Sprintf("%s-%s", tag, uniuri.NewLen(6))
 
 	// add consumer to list of consumers of this queue
 	if ok := queue.redisClient.SAdd(queue.consumersKey, name); !ok {
-		log.Panicf("rmq queue failed to add consumer %s %s", queue, tag)
+		Panicf("rmq queue failed to add consumer %s %s", queue, tag)
 	}
 
 	// log.Printf("rmq queue added consumer %s %s", queue, name)

--- a/redis_wrapper.go
+++ b/redis_wrapper.go
@@ -1,7 +1,6 @@
 package rmq
 
 import (
-	"log"
 	"time"
 
 	"github.com/go-redis/redis"
@@ -93,7 +92,7 @@ func checkErr(err error) (ok bool) {
 	case redis.Nil:
 		return false
 	default:
-		log.Panicf("rmq redis error is not nil %s", err)
+		Panicf("rmq redis error is not nil %s", err)
 		return false
 	}
 }


### PR DESCRIPTION
This keeps the current panic behaviour as the default but allows library users to override it if preferred.

fixes #61 (mostly)