### PR TITLE
Expose Close() on connection and stop hearbeat on Close()

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -17,6 +17,7 @@ type Connection interface {
 	OpenQueue(name string) Queue
 	CollectStats(queueList []string) Stats
 	GetOpenQueues() []string
+	Close() bool
 }
 
 // Connection is the entry point. Use a connection to access queues, consumers and deliveries
@@ -109,7 +110,7 @@ func (connection *redisConnection) StopHeartbeat() bool {
 
 func (connection *redisConnection) Close() bool {
 	_, ok := connection.redisClient.SRem(connectionsKey, connection.Name)
-	return ok
+	return ok && connection.StopHeartbeat()
 }
 
 // GetOpenQueues returns a list of all open queues

--- a/test_connection.go
+++ b/test_connection.go
@@ -52,3 +52,7 @@ func (connection TestConnection) Reset() {
 func (connection TestConnection) GetOpenQueues() []string {
 	return []string{}
 }
+
+func (connection TestConnection) Close() bool {
+	return true
+}


### PR DESCRIPTION
Currently there is no way to re-establish a failed connection without crashing the Go runtime. Also there is no way outside of `Cleaner` to `Close` a connection, but that will not close a connection if the heatbeat goroutine is still alive - and there is no public way to do that.

This change will allow me to cleanup a failed connection, re-establish a connection, clean the old connection, and carry on processing.

The pattern of exported functions on unexported types is quite awkward... I wonder if we could make some wider changes to make rmq more usable from a service that doesn't want to crash when its workers do, or need to be restarted.

Currently this is making it hard for me to integration test resumption, but I also want crash-recover of workers in my main service as per #61 

Signed-off-by: Silas Davis <silas@monax.io>