### PR TITLE
Added Support for Bulk Publishing

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -31,7 +31,7 @@ const (
 )
 
 type Queue interface {
-	Publish(payload string) bool
+	Publish(payload ...string) bool
 	PublishBytes(payload []byte) bool
 	SetPushQueue(pushQueue Queue)
 	StartConsuming(prefetchLimit int, pollDuration time.Duration) bool
@@ -93,9 +93,8 @@ func (queue *redisQueue) String() string {
 }
 
 // Publish adds a delivery with the given payload to the queue
-func (queue *redisQueue) Publish(payload string) bool {
-	// debug(fmt.Sprintf("publish %s %s", payload, queue)) // COMMENTOUT
-	return queue.redisClient.LPush(queue.readyKey, payload)
+func (queue *redisQueue) Publish(payload ...string) bool {
+	return queue.redisClient.LPush(queue.readyKey, payload...)
 }
 
 // PublishBytes just casts the bytes and calls Publish

--- a/queue.go
+++ b/queue.go
@@ -32,7 +32,7 @@ const (
 
 type Queue interface {
 	Publish(payload ...string) bool
-	PublishBytes(payload []byte) bool
+	PublishBytes(payload ...[]byte) bool
 	SetPushQueue(pushQueue Queue)
 	StartConsuming(prefetchLimit int, pollDuration time.Duration) bool
 	StopConsuming() <-chan struct{}
@@ -98,8 +98,12 @@ func (queue *redisQueue) Publish(payload ...string) bool {
 }
 
 // PublishBytes just casts the bytes and calls Publish
-func (queue *redisQueue) PublishBytes(payload []byte) bool {
-	return queue.Publish(string(payload))
+func (queue *redisQueue) PublishBytes(payload ...[]byte) bool {
+	stringifiedBytes := make([]string, len(payload))
+	for i, b := range payload {
+		stringifiedBytes[i] = string(b)
+	}
+	return queue.Publish(stringifiedBytes...)
 }
 
 // PurgeReady removes all ready deliveries from the queue and returns the number of purged deliveries

--- a/redis_client.go
+++ b/redis_client.go
@@ -9,7 +9,7 @@ type RedisClient interface {
 	TTL(key string) (ttl time.Duration, ok bool) // default ttl: 0
 
 	// lists
-	LPush(key, value string) bool
+	LPush(key string, value ...string) bool
 	LLen(key string) (affected int, ok bool)
 	LRem(key string, count int, value string) (affected int, ok bool)
 	LTrim(key string, start, stop int)

--- a/redis_wrapper.go
+++ b/redis_wrapper.go
@@ -33,7 +33,7 @@ func (wrapper RedisWrapper) TTL(key string) (ttl time.Duration, ok bool) {
 	return ttl, ok
 }
 
-func (wrapper RedisWrapper) LPush(key, value string) bool {
+func (wrapper RedisWrapper) LPush(key string, value ...string) bool {
 	return checkErr(wrapper.rawClient.LPush(key, value).Err())
 }
 

--- a/test_queue.go
+++ b/test_queue.go
@@ -17,8 +17,8 @@ func (queue *TestQueue) String() string {
 	return queue.name
 }
 
-func (queue *TestQueue) Publish(payload string) bool {
-	queue.LastDeliveries = append(queue.LastDeliveries, payload)
+func (queue *TestQueue) Publish(payload ...string) bool {
+	queue.LastDeliveries = append(queue.LastDeliveries, payload...)
 	return true
 }
 

--- a/test_queue.go
+++ b/test_queue.go
@@ -22,8 +22,12 @@ func (queue *TestQueue) Publish(payload ...string) bool {
 	return true
 }
 
-func (queue *TestQueue) PublishBytes(payload []byte) bool {
-	return queue.Publish(string(payload))
+func (queue *TestQueue) PublishBytes(payload ...[]byte) bool {
+	stringifiedBytes := make([]string, len(payload))
+	for i, b := range payload {
+		stringifiedBytes[i] = string(b)
+	}
+	return queue.Publish(stringifiedBytes...)
 }
 
 func (queue *TestQueue) SetPushQueue(pushQueue Queue) {

--- a/test_redis_client.go
+++ b/test_redis_client.go
@@ -114,7 +114,7 @@ func (client *TestRedisClient) TTL(key string) (ttl time.Duration, ok bool) {
 // It is possible to push multiple elements using a single command call just specifying multiple arguments
 // at the end of the command. Elements are inserted one after the other to the head of the list,
 // from the leftmost element to the rightmost element.
-func (client *TestRedisClient) LPush(key, value string) bool {
+func (client *TestRedisClient) LPush(key string, value ...string) bool {
 
 	lock.Lock()
 	defer lock.Unlock()
@@ -125,7 +125,7 @@ func (client *TestRedisClient) LPush(key, value string) bool {
 		return false
 	}
 
-	client.storeList(key, append([]string{value}, list...))
+	client.storeList(key, append(value, list...))
 	return true
 }
 


### PR DESCRIPTION
## Changelog
* `Publish` and `PublishBytes` now supports multiple values against a single key, making it compliant with the actual redis command.

Fixes #73 