### PR TITLE
rename FLushDb to FlushDB

### DIFF
--- a/redis_wrapper.go
+++ b/redis_wrapper.go
@@ -82,7 +82,7 @@ func (wrapper RedisWrapper) SRem(key, value string) (affected int, ok bool) {
 }
 
 func (wrapper RedisWrapper) FlushDb() {
-	wrapper.rawClient.FlushDb()
+	wrapper.rawClient.FlushDB()
 }
 
 // checkErr returns true if there is no error, false if the result error is nil and panics if there's another error


### PR DESCRIPTION
fix for wrapper.rawClient.FlushDb undefined (type *redis.Client has no field or method FlushDb)
related issue : [71](https://github.com/adjust/rmq/issues/71)