### PR TITLE
Fix connections unack messages to be equal to prefetchLimit

### DIFF
--- a/cleaner_test.go
+++ b/cleaner_test.go
@@ -51,8 +51,8 @@ func (suite *CleanerSuite) TestCleaner(c *C) {
 
 	queue.AddConsumer("consumer1", consumer)
 	time.Sleep(10 * time.Millisecond)
-	c.Check(queue.UnackedCount(), Equals, 3)
-	c.Check(queue.ReadyCount(), Equals, 3)
+	c.Check(queue.UnackedCount(), Equals, 2)
+	c.Check(queue.ReadyCount(), Equals, 4)
 
 	c.Assert(consumer.LastDelivery, NotNil)
 	c.Check(consumer.LastDelivery.Payload(), Equals, "del1")
@@ -63,8 +63,8 @@ func (suite *CleanerSuite) TestCleaner(c *C) {
 
 	consumer.Finish()
 	time.Sleep(10 * time.Millisecond)
-	c.Check(queue.UnackedCount(), Equals, 3)
-	c.Check(queue.ReadyCount(), Equals, 2)
+	c.Check(queue.UnackedCount(), Equals, 2)
+	c.Check(queue.ReadyCount(), Equals, 3)
 	c.Check(consumer.LastDelivery.Payload(), Equals, "del2")
 
 	queue.StopConsuming()
@@ -75,21 +75,21 @@ func (suite *CleanerSuite) TestCleaner(c *C) {
 	queue = conn.OpenQueue("q1").(*redisQueue)
 
 	queue.Publish("del7")
-	c.Check(queue.ReadyCount(), Equals, 3)
-	queue.Publish("del7")
 	c.Check(queue.ReadyCount(), Equals, 4)
-	queue.Publish("del8")
+	queue.Publish("del7")
 	c.Check(queue.ReadyCount(), Equals, 5)
-	queue.Publish("del9")
+	queue.Publish("del8")
 	c.Check(queue.ReadyCount(), Equals, 6)
-	queue.Publish("del10")
+	queue.Publish("del9")
 	c.Check(queue.ReadyCount(), Equals, 7)
+	queue.Publish("del10")
+	c.Check(queue.ReadyCount(), Equals, 8)
 
 	c.Check(queue.UnackedCount(), Equals, 0)
 	queue.StartConsuming(2, time.Millisecond)
 	time.Sleep(time.Millisecond)
 	c.Check(queue.UnackedCount(), Equals, 2)
-	c.Check(queue.ReadyCount(), Equals, 5)
+	c.Check(queue.ReadyCount(), Equals, 6)
 
 	consumer = NewTestConsumer("c-B")
 	consumer.AutoFinish = false
@@ -97,20 +97,20 @@ func (suite *CleanerSuite) TestCleaner(c *C) {
 
 	queue.AddConsumer("consumer2", consumer)
 	time.Sleep(10 * time.Millisecond)
-	c.Check(queue.UnackedCount(), Equals, 3)
-	c.Check(queue.ReadyCount(), Equals, 4)
-	c.Check(consumer.LastDelivery.Payload(), Equals, "del5")
+	c.Check(queue.UnackedCount(), Equals, 2)
+	c.Check(queue.ReadyCount(), Equals, 6)
+	c.Check(consumer.LastDelivery.Payload(), Equals, "del4")
 
 	consumer.Finish() // unacked
 	time.Sleep(10 * time.Millisecond)
-	c.Check(queue.UnackedCount(), Equals, 4)
-	c.Check(queue.ReadyCount(), Equals, 3)
+	c.Check(queue.UnackedCount(), Equals, 2)
+	c.Check(queue.ReadyCount(), Equals, 6)
 
-	c.Check(consumer.LastDelivery.Payload(), Equals, "del6")
+	c.Check(consumer.LastDelivery.Payload(), Equals, "del5")
 	c.Check(consumer.LastDelivery.Ack(), Equals, true)
 	time.Sleep(10 * time.Millisecond)
-	c.Check(queue.UnackedCount(), Equals, 3)
-	c.Check(queue.ReadyCount(), Equals, 3)
+	c.Check(queue.UnackedCount(), Equals, 2)
+	c.Check(queue.ReadyCount(), Equals, 5)
 
 	queue.StopConsuming()
 	conn.StopHeartbeat()

--- a/queue.go
+++ b/queue.go
@@ -316,8 +316,10 @@ func (queue *redisQueue) consume() {
 }
 
 func (queue *redisQueue) batchSize() int {
-	prefetchCount := len(queue.deliveryChan)
-	prefetchLimit := queue.prefetchLimit - prefetchCount
+	// prefetchCount := len(queue.deliveryChan)
+	// prefetchLimit := queue.prefetchLimit - prefetchCount
+	prefetchLimit := queue.prefetchLimit - queue.UnackedCount() 
+
 	// TODO: ignore ready count here and just return prefetchLimit?
 	if readyCount := queue.ReadyCount(); readyCount < prefetchLimit {
 		return readyCount

--- a/queue_test.go
+++ b/queue_test.go
@@ -230,8 +230,8 @@ func (suite *QueueSuite) TestMulti(c *C) {
 
 	queue.AddConsumer("multi-cons", consumer)
 	time.Sleep(10 * time.Millisecond)
-	c.Check(queue.ReadyCount(), Equals, 9)
-	c.Check(queue.UnackedCount(), Equals, 11)
+	c.Check(queue.ReadyCount(), Equals, 10)
+	c.Check(queue.UnackedCount(), Equals, 10)
 
 	c.Check(consumer.LastDelivery.Ack(), Equals, true)
 	time.Sleep(10 * time.Millisecond)
@@ -240,8 +240,8 @@ func (suite *QueueSuite) TestMulti(c *C) {
 
 	consumer.Finish()
 	time.Sleep(10 * time.Millisecond)
-	c.Check(queue.ReadyCount(), Equals, 8)
-	c.Check(queue.UnackedCount(), Equals, 11)
+	c.Check(queue.ReadyCount(), Equals, 9)
+	c.Check(queue.UnackedCount(), Equals, 10)
 
 	c.Check(consumer.LastDelivery.Ack(), Equals, true)
 	time.Sleep(10 * time.Millisecond)
@@ -250,8 +250,8 @@ func (suite *QueueSuite) TestMulti(c *C) {
 
 	consumer.Finish()
 	time.Sleep(10 * time.Millisecond)
-	c.Check(queue.ReadyCount(), Equals, 7)
-	c.Check(queue.UnackedCount(), Equals, 11)
+	c.Check(queue.ReadyCount(), Equals, 8)
+	c.Check(queue.UnackedCount(), Equals, 10)
 
 	queue.StopConsuming()
 	connection.StopHeartbeat()


### PR DESCRIPTION
Currently connection is taking prefetchLimit number of messages in delivery chain hence connection holds more than prefetchLimit of messages unacknowledged at any time.
Because number of messages unack by connection at any time =  messages in consumption + messages waiting in delivery channel.

This commit is to make connections unack messages equal to prefetchLimit.

Changing the test cases according to the new change.