### PR TITLE
redisConnection must be exported variable

### DIFF
--- a/cleaner.go
+++ b/cleaner.go
@@ -11,7 +11,7 @@ func NewCleaner(connection Connection) *Cleaner {
 }
 
 func (cleaner *Cleaner) Clean() error {
-	cleanerConnection, ok := cleaner.connection.(*redisConnection)
+	cleanerConnection, ok := cleaner.connection.(*RedisConnection)
 	if !ok {
 		return nil
 	}
@@ -30,7 +30,7 @@ func (cleaner *Cleaner) Clean() error {
 	return nil
 }
 
-func CleanConnection(connection *redisConnection) error {
+func CleanConnection(connection *RedisConnection) error {
 	queueNames := connection.GetConsumingQueues()
 	for _, queueName := range queueNames {
 		queue, ok := connection.OpenQueue(queueName).(*redisQueue)

--- a/connection.go
+++ b/connection.go
@@ -21,7 +21,7 @@ type Connection interface {
 
 // Connection is the entry point. Use a connection to access queues, consumers and deliveries
 // Each connection has a single heartbeat shared among all consumers
-type redisConnection struct {
+type RedisConnection struct {
 	Name             string
 	heartbeatKey     string // key to keep alive
 	queuesKey        string // key to list of queues consumed by this connection
@@ -30,20 +30,20 @@ type redisConnection struct {
 }
 
 // OpenConnectionWithRedisClient opens and returns a new connection
-func OpenConnectionWithRedisClient(tag string, redisClient *redis.Client) *redisConnection {
+func OpenConnectionWithRedisClient(tag string, redisClient *redis.Client) *RedisConnection {
 	return openConnectionWithRedisClient(tag, RedisWrapper{redisClient})
 }
 
 // OpenConnectionWithTestRedisClient opens and returns a new connection which
 // uses a test redis client internally. This is useful in integration tests.
-func OpenConnectionWithTestRedisClient(tag string) *redisConnection {
+func OpenConnectionWithTestRedisClient(tag string) *RedisConnection {
 	return openConnectionWithRedisClient(tag, NewTestRedisClient())
 }
 
-func openConnectionWithRedisClient(tag string, redisClient RedisClient) *redisConnection {
+func openConnectionWithRedisClient(tag string, redisClient RedisClient) *RedisConnection {
 	name := fmt.Sprintf("%s-%s", tag, uniuri.NewLen(6))
 
-	connection := &redisConnection{
+	connection := &RedisConnection{
 		Name:         name,
 		heartbeatKey: strings.Replace(connectionHeartbeatTemplate, phConnection, name, 1),
 		queuesKey:    strings.Replace(connectionQueuesTemplate, phConnection, name, 1),
@@ -63,7 +63,7 @@ func openConnectionWithRedisClient(tag string, redisClient RedisClient) *redisCo
 }
 
 // OpenConnection opens and returns a new connection
-func OpenConnection(tag, network, address string, db int) *redisConnection {
+func OpenConnection(tag, network, address string, db int) *RedisConnection {
 	redisClient := redis.NewClient(&redis.Options{
 		Network: network,
 		Addr:    address,
@@ -73,27 +73,27 @@ func OpenConnection(tag, network, address string, db int) *redisConnection {
 }
 
 // OpenQueue opens and returns the queue with a given name
-func (connection *redisConnection) OpenQueue(name string) Queue {
+func (connection *RedisConnection) OpenQueue(name string) Queue {
 	connection.redisClient.SAdd(queuesKey, name)
 	queue := newQueue(name, connection.Name, connection.queuesKey, connection.redisClient)
 	return queue
 }
 
-func (connection *redisConnection) CollectStats(queueList []string) Stats {
+func (connection *RedisConnection) CollectStats(queueList []string) Stats {
 	return CollectStats(queueList, connection)
 }
 
-func (connection *redisConnection) String() string {
+func (connection *RedisConnection) String() string {
 	return connection.Name
 }
 
 // GetConnections returns a list of all open connections
-func (connection *redisConnection) GetConnections() []string {
+func (connection *RedisConnection) GetConnections() []string {
 	return connection.redisClient.SMembers(connectionsKey)
 }
 
 // Check retuns true if the connection is currently active in terms of heartbeat
-func (connection *redisConnection) Check() bool {
+func (connection *RedisConnection) Check() bool {
 	heartbeatKey := strings.Replace(connectionHeartbeatTemplate, phConnection, connection.Name, 1)
 	ttl, _ := connection.redisClient.TTL(heartbeatKey)
 	return ttl > 0
@@ -101,42 +101,42 @@ func (connection *redisConnection) Check() bool {
 
 // StopHeartbeat stops the heartbeat of the connection
 // it does not remove it from the list of connections so it can later be found by the cleaner
-func (connection *redisConnection) StopHeartbeat() bool {
+func (connection *RedisConnection) StopHeartbeat() bool {
 	connection.heartbeatStopped = true
 	_, ok := connection.redisClient.Del(connection.heartbeatKey)
 	return ok
 }
 
-func (connection *redisConnection) Close() bool {
+func (connection *RedisConnection) Close() bool {
 	_, ok := connection.redisClient.SRem(connectionsKey, connection.Name)
 	return ok
 }
 
 // GetOpenQueues returns a list of all open queues
-func (connection *redisConnection) GetOpenQueues() []string {
+func (connection *RedisConnection) GetOpenQueues() []string {
 	return connection.redisClient.SMembers(queuesKey)
 }
 
 // CloseAllQueues closes all queues by removing them from the global list
-func (connection *redisConnection) CloseAllQueues() int {
+func (connection *RedisConnection) CloseAllQueues() int {
 	count, _ := connection.redisClient.Del(queuesKey)
 	return count
 }
 
 // CloseAllQueuesInConnection closes all queues in the associated connection by removing all related keys
-func (connection *redisConnection) CloseAllQueuesInConnection() error {
+func (connection *RedisConnection) CloseAllQueuesInConnection() error {
 	connection.redisClient.Del(connection.queuesKey)
 	// debug(fmt.Sprintf("connection closed all queues %s %d", connection, connection.queuesKey)) // COMMENTOUT
 	return nil
 }
 
 // GetConsumingQueues returns a list of all queues consumed by this connection
-func (connection *redisConnection) GetConsumingQueues() []string {
+func (connection *RedisConnection) GetConsumingQueues() []string {
 	return connection.redisClient.SMembers(connection.queuesKey)
 }
 
 // heartbeat keeps the heartbeat key alive
-func (connection *redisConnection) heartbeat() {
+func (connection *RedisConnection) heartbeat() {
 	for {
 		if !connection.updateHeartbeat() {
 			// log.Printf("rmq connection failed to update heartbeat %s", connection)
@@ -151,14 +151,14 @@ func (connection *redisConnection) heartbeat() {
 	}
 }
 
-func (connection *redisConnection) updateHeartbeat() bool {
+func (connection *RedisConnection) updateHeartbeat() bool {
 	ok := connection.redisClient.Set(connection.heartbeatKey, "1", heartbeatDuration)
 	return ok
 }
 
 // hijackConnection reopens an existing connection for inspection purposes without starting a heartbeat
-func (connection *redisConnection) hijackConnection(name string) *redisConnection {
-	return &redisConnection{
+func (connection *RedisConnection) hijackConnection(name string) *RedisConnection {
+	return &RedisConnection{
 		Name:         name,
 		heartbeatKey: strings.Replace(connectionHeartbeatTemplate, phConnection, name, 1),
 		queuesKey:    strings.Replace(connectionQueuesTemplate, phConnection, name, 1),
@@ -167,11 +167,11 @@ func (connection *redisConnection) hijackConnection(name string) *redisConnectio
 }
 
 // openQueue opens a queue without adding it to the set of queues
-func (connection *redisConnection) openQueue(name string) *redisQueue {
+func (connection *RedisConnection) openQueue(name string) *redisQueue {
 	return newQueue(name, connection.Name, connection.queuesKey, connection.redisClient)
 }
 
 // flushDb flushes the redis database to reset everything, used in tests
-func (connection *redisConnection) flushDb() {
+func (connection *RedisConnection) flushDb() {
 	connection.redisClient.FlushDb()
 }

--- a/stats.go
+++ b/stats.go
@@ -77,7 +77,7 @@ func NewStats() Stats {
 	}
 }
 
-func CollectStats(queueList []string, mainConnection *redisConnection) Stats {
+func CollectStats(queueList []string, mainConnection *RedisConnection) Stats {
 	stats := NewStats()
 	for _, queueName := range queueList {
 		queue := mainConnection.openQueue(queueName)


### PR DESCRIPTION
rmq.OpenConnection method returns *redisConnection . Thus, If we want to persist variable in any other struct it is not allowing.
Consider following example : 
```
type RedisQueueDB struct {
	Tag      string
	Network  string
	Address  string
	Queue    string
	DB       int
	DataChan chan Action
	RedisConn *rmq.redisConnection
}
```
So I want to initialize redisConnection only once and want to reuse same connection through my RedisQueueDB.RedisConn object.

but , it is giving error as below : 
redisConnection not exported by package rmq

Made change in repo accordingly . please review