### PR TITLE
All examples now use v4 imports instead of v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Note**: We recently updated rmq to expose Redis errors instead of panicking.
 This is a major change as almost all functions now return errors. It's
-recommended to switch to this new version `rmq/v3` so rmq won't crash your
+recommended to switch to the latest version `rmq/v4` so rmq won't crash your
 services anymore on Redis errors.
 
 If you don't want to upgrade yet, you can continue using `rmq/v2`.
@@ -29,7 +29,7 @@ Let's take a look at how to use rmq.
 Of course you need to import rmq wherever you want to use it.
 
 ```go
-import "github.com/adjust/rmq/v3"
+import "github.com/adjust/rmq/v4"
 ```
 
 ### Connection

--- a/example/batch_consumer/main.go
+++ b/example/batch_consumer/main.go
@@ -7,7 +7,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/adjust/rmq/v3"
+	"github.com/adjust/rmq/v4"
 )
 
 const (

--- a/example/cleaner/main.go
+++ b/example/cleaner/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/adjust/rmq/v3"
+	"github.com/adjust/rmq/v4"
 )
 
 func main() {

--- a/example/consumer/main.go
+++ b/example/consumer/main.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/adjust/rmq/v3"
+	"github.com/adjust/rmq/v4"
 )
 
 const (

--- a/example/handler/main.go
+++ b/example/handler/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/adjust/rmq/v3"
+	"github.com/adjust/rmq/v4"
 )
 
 func main() {

--- a/example/producer/main.go
+++ b/example/producer/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/adjust/rmq/v3"
+	"github.com/adjust/rmq/v4"
 )
 
 const (

--- a/example/purger/main.go
+++ b/example/purger/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	"github.com/adjust/rmq/v3"
+	"github.com/adjust/rmq/v4"
 )
 
 func main() {

--- a/example/returner/main.go
+++ b/example/returner/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"math"
 
-	"github.com/adjust/rmq/v3"
+	"github.com/adjust/rmq/v4"
 )
 
 func main() {


### PR DESCRIPTION
Our examples were importing v3 versions of RMQ. Now importing v4.