### PR TITLE
🎨 feat: change `*redis.Client` to `redis.Cmable` interface to support…

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -67,7 +67,7 @@ func OpenConnection(tag string, network string, address string, db int, errChan 
 }
 
 // OpenConnectionWithRedisClient opens and returns a new connection
-func OpenConnectionWithRedisClient(tag string, redisClient *redis.Client, errChan chan<- error) (Connection, error) {
+func OpenConnectionWithRedisClient(tag string, redisClient redis.Cmdable, errChan chan<- error) (Connection, error) {
 	return OpenConnectionWithRmqRedisClient(tag, RedisWrapper{redisClient}, errChan)
 }
 

--- a/redis_wrapper.go
+++ b/redis_wrapper.go
@@ -10,7 +10,7 @@ import (
 var unusedContext = context.TODO()
 
 type RedisWrapper struct {
-	rawClient *redis.Client
+	rawClient redis.Cmdable
 }
 
 func (wrapper RedisWrapper) Set(key string, value string, expiration time.Duration) error {


### PR DESCRIPTION
This PR will allow us to pass redis client cluster, example :

```go
client := redis.NewClusterClient(&redis.ClusterOptions{
	Addrs:    []string{"127.0.0.1:8000", "127.0.0.1: 8001"},
})

errChan := make(chan error, 1)
rmq.OpenConnectionWithRmqRedisClient("queue-name", client, errChan)
```

Noted: There have no breaking change in this PR, as long as we are using `redis/v8` (this will comply to the interface)