### PR TITLE
add push priority method for right push vs left push into list

### DIFF
--- a/redis_client.go
+++ b/redis_client.go
@@ -10,6 +10,7 @@ type RedisClient interface {
 
 	// lists
 	LPush(key string, value ...string) (total int64, err error)
+	RPush(key string, value ...string) (total int64, err error)
 	LLen(key string) (affected int64, err error)
 	LRem(key string, count int64, value string) (affected int64, err error)
 	LTrim(key string, start, stop int64) error

--- a/redis_wrapper.go
+++ b/redis_wrapper.go
@@ -30,6 +30,10 @@ func (wrapper RedisWrapper) LPush(key string, value ...string) (total int64, err
 	return wrapper.rawClient.LPush(unusedContext, key, value).Result()
 }
 
+func (wrapper RedisWrapper) RPush(key string, value ...string) (total int64, err error) {
+	return wrapper.rawClient.RPush(unusedContext, key, value).Result()
+}
+
 func (wrapper RedisWrapper) LLen(key string) (affected int64, err error) {
 	return wrapper.rawClient.LLen(unusedContext, key).Result()
 }

--- a/test_delivery.go
+++ b/test_delivery.go
@@ -56,3 +56,11 @@ func (delivery *TestDelivery) Push() error {
 	delivery.State = Pushed
 	return nil
 }
+
+func (delivery *TestDelivery) PushPriority() error {
+	if delivery.State != Unacked {
+		return ErrorNotFound
+	}
+	delivery.State = Pushed
+	return nil
+}

--- a/test_redis_client.go
+++ b/test_redis_client.go
@@ -129,6 +129,27 @@ func (client *TestRedisClient) LPush(key string, value ...string) (total int64, 
 	return int64(len(list)) + 1, nil
 }
 
+// RPush inserts the specified value at the tail of the list stored at key.
+// If key does not exist, it is created as empty list before performing the push operations.
+// When key holds a value that is not a list, an error is returned.
+// It is possible to push multiple elements using a single command call just specifying multiple arguments
+// at the end of the command. Elements are inserted one after the other to the head of the list,
+// from the leftmost element to the rightmost element.
+func (client *TestRedisClient) RPush(key string, value ...string) (total int64, err error) {
+
+	lock.Lock()
+	defer lock.Unlock()
+
+	list, err := client.findList(key)
+
+	if err != nil {
+		return 0, nil
+	}
+
+	client.storeList(key, append(list, value...))
+	return int64(len(list)) + 1, nil
+}
+
 //LLen returns the length of the list stored at key.
 //If key does not exist, it is interpreted as an empty list and 0 is returned.
 //An error is returned when the value stored at key is not a list.


### PR DESCRIPTION
Thoughts on this?

The scenario I've come across where I need this is that there are situations where you might want to push a message to the prescribed push queue, but at the tail of the list rather than the head. An example is a consumer that might be long running, where the consumer takes a context and can be be interrupted. In such a case, we might ideally start re-processing that message sooner than other queued items in the list for the purposes of logs for certain types of messages being more or less sequential, etc.. etc..  This is definitely in the "nice to have" column for me and I'm curious what others think.