### PR TITLE
Add jitter to poll duration

### DIFF
--- a/queue_test.go
+++ b/queue_test.go
@@ -741,3 +741,11 @@ func BenchmarkQueue(b *testing.B) {
 
 	assert.NoError(b, connection.stopHeartbeat())
 }
+
+func Test_jitteredDuration(t *testing.T) {
+	dur := 100 * time.Millisecond
+	for i := 0; i < 5000; i++ {
+		assert.LessOrEqual(t, int64(90*time.Millisecond), int64(jitteredDuration(dur)))
+		assert.GreaterOrEqual(t, int64(110*time.Millisecond), int64(jitteredDuration(dur)))
+	}
+}

--- a/queue_test.go
+++ b/queue_test.go
@@ -745,7 +745,8 @@ func BenchmarkQueue(b *testing.B) {
 func Test_jitteredDuration(t *testing.T) {
 	dur := 100 * time.Millisecond
 	for i := 0; i < 5000; i++ {
-		assert.LessOrEqual(t, int64(90*time.Millisecond), int64(jitteredDuration(dur)))
-		assert.GreaterOrEqual(t, int64(110*time.Millisecond), int64(jitteredDuration(dur)))
+		d := jitteredDuration(dur)
+		assert.LessOrEqual(t, int64(90*time.Millisecond), int64(d))
+		assert.GreaterOrEqual(t, int64(110*time.Millisecond), int64(d))
 	}
 }


### PR DESCRIPTION
when you create multiple rmq connections with the same poll duration, this creates a staggered consumption of data from the que where the first connections consume all he data leaving almost none for the rest. 

This pr introduces a +/-10% jitter to the poll duration to prevent the predictable consumption and solve the stagger. 