### PR TITLE
Use default rand in jitteredDuration

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -14,8 +14,6 @@ const (
 	purgeBatchSize      = int64(100)
 )
 
-var randSrc = rand.New(rand.NewSource(time.Now().UnixNano()))
-
 type Queue interface {
 	Publish(payload ...string) error
 	PublishBytes(payload ...[]byte) error
@@ -535,6 +533,6 @@ func (queue *redisQueue) ensureConsuming() error {
 
 // jitteredDuration calculates and returns a value that is +/-10% the input duration
 func jitteredDuration(duration time.Duration) time.Duration {
-	factor := 0.9 + randSrc.Float64()*0.2 // a jitter factor between 0.9 and 1.1 (+-10%)
+	factor := 0.9 + rand.Float64()*0.2 // a jitter factor between 0.9 and 1.1 (+-10%)
 	return time.Duration(float64(duration) * factor)
 }


### PR DESCRIPTION
jitteredDuration introduced in https://github.com/adjust/rmq/pull/116 uses rand.NewSource which is not safe for concurrent use by multiple goroutines.
https://github.com/golang/go/blob/8f53fad035ccc580859f7b063ae8be30b009a6be/src/math/rand/rand.go#L41

This PR updates jitterredDuration to use the default rand (the default Source is safe for concurrent use by multiple goroutines) which is already seeded in  https://github.com/adjust/rmq/blob/master/rand.go#L9 