### PR TITLE
New Wrapper for cluster as in ISSUE #113

### DIFF
--- a/cleaner_test.go
+++ b/cleaner_test.go
@@ -9,12 +9,12 @@ import (
 )
 
 func TestCleaner(t *testing.T) {
-	flushConn, err := OpenConnection("cleaner-flush", "tcp", "localhost:6379", 1, nil)
+	flushConn, err := OpenConnection("cleaner-flush", sOp, nil)
 	assert.NoError(t, err)
 	assert.NoError(t, flushConn.stopHeartbeat())
 	assert.NoError(t, flushConn.flushDb())
 
-	conn, err := OpenConnection("cleaner-conn1", "tcp", "localhost:6379", 1, nil)
+	conn, err := OpenConnection("cleaner-conn1", sOp, nil)
 	assert.NoError(t, err)
 	queues, err := conn.GetOpenQueues()
 	assert.NoError(t, err)
@@ -75,7 +75,7 @@ func TestCleaner(t *testing.T) {
 	assert.NoError(t, conn.stopHeartbeat())
 	time.Sleep(time.Millisecond)
 
-	conn, err = OpenConnection("cleaner-conn1", "tcp", "localhost:6379", 1, nil)
+	conn, err = OpenConnection("cleaner-conn1", sOp, nil)
 	assert.NoError(t, err)
 	queue, err = conn.OpenQueue("q1")
 	assert.NoError(t, err)
@@ -122,7 +122,7 @@ func TestCleaner(t *testing.T) {
 	assert.NoError(t, conn.stopHeartbeat())
 	time.Sleep(time.Millisecond)
 
-	cleanerConn, err := OpenConnection("cleaner-conn", "tcp", "localhost:6379", 1, nil)
+	cleanerConn, err := OpenConnection("cleaner-conn", sOp, nil)
 	assert.NoError(t, err)
 	cleaner := NewCleaner(cleanerConn)
 	returned, err := cleaner.Clean()
@@ -133,7 +133,7 @@ func TestCleaner(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, queues, 2)
 
-	conn, err = OpenConnection("cleaner-conn1", "tcp", "localhost:6379", 1, nil)
+	conn, err = OpenConnection("cleaner-conn1", sOp, nil)
 	assert.NoError(t, err)
 	queue, err = conn.OpenQueue("q1")
 	assert.NoError(t, err)

--- a/connection.go
+++ b/connection.go
@@ -61,14 +61,15 @@ type redisConnection struct {
 }
 
 // OpenConnection opens and returns a new connection
-func OpenConnection(tag string, network string, address string, db int, errChan chan<- error) (Connection, error) {
-	redisClient := redis.NewClient(&redis.Options{Network: network, Addr: address, DB: db})
-	return OpenConnectionWithRedisClient(tag, redisClient, errChan)
+func OpenConnection(tag string, redisOption *redis.Options, errChan chan<- error) (Connection, error) {
+	// redisClient := redis.NewClient(&redis.Options{Network: network, Addr: address, DB: db})
+	redisClient := redis.NewClient(redisOption)
+	return OpenConnectionWithRmqRedisClient(tag, RedisSingleWrapper{redisClient}, errChan)
 }
 
-// OpenConnectionWithRedisClient opens and returns a new connection
-func OpenConnectionWithRedisClient(tag string, redisClient redis.Cmdable, errChan chan<- error) (Connection, error) {
-	return OpenConnectionWithRmqRedisClient(tag, RedisWrapper{redisClient}, errChan)
+// OpenConnectionWithRedisClusterClient opens and returns a new connection for a cluster redis
+func OpenConnectionWithRedisClusterClient(tag string, clusterClient *redis.ClusterClient, errChan chan<- error) (Connection, error) {
+	return OpenConnectionWithRmqRedisClient(tag, RedisClusterWrapper{clusterClient}, errChan)
 }
 
 // OpenConnectionWithTestRedisClient opens and returns a new connection which
@@ -77,7 +78,7 @@ func OpenConnectionWithTestRedisClient(tag string, errChan chan<- error) (Connec
 	return OpenConnectionWithRmqRedisClient(tag, NewTestRedisClient(), errChan)
 }
 
-// If you would like to use a redis client other than the ones supported in the constructors above, you can implement
+// OpenConnectionWithRmqRedisClient If you would like to use a redis client other than the ones supported in the constructors above, you can implement
 // the RedisClient interface yourself
 func OpenConnectionWithRmqRedisClient(tag string, redisClient RedisClient, errChan chan<- error) (Connection, error) {
 	name := fmt.Sprintf("%s-%s", tag, RandomString(6))

--- a/queue_test.go
+++ b/queue_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var sOp = &redis.Options{
-	Addr:     "8.142.103.74:32639",
+	Addr:     "localhost:6701",
 	Password: "MTIzNDUzCg==",
 }
 

--- a/redis_keys.go
+++ b/redis_keys.go
@@ -4,12 +4,12 @@ const (
 	connectionsKey                   = "rmq::connections"                                           // Set of connection names
 	connectionHeartbeatTemplate      = "rmq::connection::{connection}::heartbeat"                   // expires after {connection} died
 	connectionQueuesTemplate         = "rmq::connection::{connection}::queues"                      // Set of queues consumers of {connection} are consuming
-	connectionQueueConsumersTemplate = "rmq::connection::{connection}::queue::[{queue}]::consumers" // Set of all consumers from {connection} consuming from {queue}
-	connectionQueueUnackedTemplate   = "rmq::connection::{connection}::queue::[{queue}]::unacked"   // List of deliveries consumers of {connection} are currently consuming
+	connectionQueueConsumersTemplate = "rmq::connection::{connection}::queue::{{queue}}::consumers" // Set of all consumers from {connection} consuming from {queue}
+	connectionQueueUnackedTemplate   = "rmq::connection::{connection}::queue::{{queue}}::unacked"   // List of deliveries consumers of {connection} are currently consuming
 
 	queuesKey             = "rmq::queues"                     // Set of all open queues
-	queueReadyTemplate    = "rmq::queue::[{queue}]::ready"    // List of deliveries in that {queue} (right is first and oldest, left is last and youngest)
-	queueRejectedTemplate = "rmq::queue::[{queue}]::rejected" // List of rejected deliveries from that {queue}
+	queueReadyTemplate    = "rmq::queue::{{queue}}::ready"    // List of deliveries in that {queue} (right is first and oldest, left is last and youngest)
+	queueRejectedTemplate = "rmq::queue::{{queue}}::rejected" // List of rejected deliveries from that {queue}
 
 	phConnection = "{connection}" // connection name
 	phQueue      = "{queue}"      // queue name

--- a/redis_wrapper_cluster.go
+++ b/redis_wrapper_cluster.go
@@ -9,45 +9,45 @@ import (
 
 var unusedContext = context.TODO()
 
-type RedisWrapper struct {
-	rawClient redis.Cmdable
+type RedisClusterWrapper struct {
+	rawClient *redis.ClusterClient
 }
 
-func (wrapper RedisWrapper) Set(key string, value string, expiration time.Duration) error {
+func (wrapper RedisClusterWrapper) Set(key string, value string, expiration time.Duration) error {
 	// NOTE: using Err() here because Result() string is always "OK"
 	return wrapper.rawClient.Set(unusedContext, key, value, expiration).Err()
 }
 
-func (wrapper RedisWrapper) Del(key string) (affected int64, err error) {
+func (wrapper RedisClusterWrapper) Del(key string) (affected int64, err error) {
 	return wrapper.rawClient.Del(unusedContext, key).Result()
 }
 
-func (wrapper RedisWrapper) TTL(key string) (ttl time.Duration, err error) {
+func (wrapper RedisClusterWrapper) TTL(key string) (ttl time.Duration, err error) {
 	return wrapper.rawClient.TTL(unusedContext, key).Result()
 }
 
-func (wrapper RedisWrapper) LPush(key string, value ...string) (total int64, err error) {
+func (wrapper RedisClusterWrapper) LPush(key string, value ...string) (total int64, err error) {
 	return wrapper.rawClient.LPush(unusedContext, key, value).Result()
 }
 
-func (wrapper RedisWrapper) LLen(key string) (affected int64, err error) {
+func (wrapper RedisClusterWrapper) LLen(key string) (affected int64, err error) {
 	return wrapper.rawClient.LLen(unusedContext, key).Result()
 }
 
-func (wrapper RedisWrapper) LRem(key string, count int64, value string) (affected int64, err error) {
+func (wrapper RedisClusterWrapper) LRem(key string, count int64, value string) (affected int64, err error) {
 	return wrapper.rawClient.LRem(unusedContext, key, int64(count), value).Result()
 }
 
-func (wrapper RedisWrapper) LTrim(key string, start, stop int64) error {
+func (wrapper RedisClusterWrapper) LTrim(key string, start, stop int64) error {
 	// NOTE: using Err() here because Result() string is always "OK"
 	return wrapper.rawClient.LTrim(unusedContext, key, int64(start), int64(stop)).Err()
 }
 
-func (wrapper RedisWrapper) RPop(key string) (value string, err error) {
+func (wrapper RedisClusterWrapper) RPop(key string) (value string, err error) {
 	return wrapper.rawClient.RPop(unusedContext, key).Result()
 }
 
-func (wrapper RedisWrapper) RPopLPush(source, destination string) (value string, err error) {
+func (wrapper RedisClusterWrapper) RPopLPush(source, destination string) (value string, err error) {
 	value, err = wrapper.rawClient.RPopLPush(unusedContext, source, destination).Result()
 	// println("RPopLPush", source, destination, value, err)
 	switch err {
@@ -60,19 +60,19 @@ func (wrapper RedisWrapper) RPopLPush(source, destination string) (value string,
 	}
 }
 
-func (wrapper RedisWrapper) SAdd(key, value string) (total int64, err error) {
+func (wrapper RedisClusterWrapper) SAdd(key, value string) (total int64, err error) {
 	return wrapper.rawClient.SAdd(unusedContext, key, value).Result()
 }
 
-func (wrapper RedisWrapper) SMembers(key string) (members []string, err error) {
+func (wrapper RedisClusterWrapper) SMembers(key string) (members []string, err error) {
 	return wrapper.rawClient.SMembers(unusedContext, key).Result()
 }
 
-func (wrapper RedisWrapper) SRem(key, value string) (affected int64, err error) {
+func (wrapper RedisClusterWrapper) SRem(key, value string) (affected int64, err error) {
 	return wrapper.rawClient.SRem(unusedContext, key, value).Result()
 }
 
-func (wrapper RedisWrapper) FlushDb() error {
+func (wrapper RedisClusterWrapper) FlushDb() error {
 	// NOTE: using Err() here because Result() string is always "OK"
 	return wrapper.rawClient.FlushDB(unusedContext).Err()
 }

--- a/redis_wrapper_single.go
+++ b/redis_wrapper_single.go
@@ -1,0 +1,75 @@
+package rmq
+
+import (
+	"time"
+
+	"github.com/go-redis/redis/v8"
+)
+
+type RedisSingleWrapper struct {
+	rawClient redis.Cmdable
+}
+
+func (wrapper RedisSingleWrapper) Set(key string, value string, expiration time.Duration) error {
+	// NOTE: using Err() here because Result() string is always "OK"
+	return wrapper.rawClient.Set(unusedContext, key, value, expiration).Err()
+}
+
+func (wrapper RedisSingleWrapper) Del(key string) (affected int64, err error) {
+	return wrapper.rawClient.Del(unusedContext, key).Result()
+}
+
+func (wrapper RedisSingleWrapper) TTL(key string) (ttl time.Duration, err error) {
+	return wrapper.rawClient.TTL(unusedContext, key).Result()
+}
+
+func (wrapper RedisSingleWrapper) LPush(key string, value ...string) (total int64, err error) {
+	return wrapper.rawClient.LPush(unusedContext, key, value).Result()
+}
+
+func (wrapper RedisSingleWrapper) LLen(key string) (affected int64, err error) {
+	return wrapper.rawClient.LLen(unusedContext, key).Result()
+}
+
+func (wrapper RedisSingleWrapper) LRem(key string, count int64, value string) (affected int64, err error) {
+	return wrapper.rawClient.LRem(unusedContext, key, int64(count), value).Result()
+}
+
+func (wrapper RedisSingleWrapper) LTrim(key string, start, stop int64) error {
+	// NOTE: using Err() here because Result() string is always "OK"
+	return wrapper.rawClient.LTrim(unusedContext, key, int64(start), int64(stop)).Err()
+}
+
+func (wrapper RedisSingleWrapper) RPop(key string) (value string, err error) {
+	return wrapper.rawClient.RPop(unusedContext, key).Result()
+}
+
+func (wrapper RedisSingleWrapper) RPopLPush(source, destination string) (value string, err error) {
+	value, err = wrapper.rawClient.RPopLPush(unusedContext, source, destination).Result()
+	// println("RPopLPush", source, destination, value, err)
+	switch err {
+	case nil:
+		return value, nil
+	case redis.Nil:
+		return value, ErrorNotFound
+	default:
+		return value, err
+	}
+}
+
+func (wrapper RedisSingleWrapper) SAdd(key, value string) (total int64, err error) {
+	return wrapper.rawClient.SAdd(unusedContext, key, value).Result()
+}
+
+func (wrapper RedisSingleWrapper) SMembers(key string) (members []string, err error) {
+	return wrapper.rawClient.SMembers(unusedContext, key).Result()
+}
+
+func (wrapper RedisSingleWrapper) SRem(key, value string) (affected int64, err error) {
+	return wrapper.rawClient.SRem(unusedContext, key, value).Result()
+}
+
+func (wrapper RedisSingleWrapper) FlushDb() error {
+	// NOTE: using Err() here because Result() string is always "OK"
+	return wrapper.rawClient.FlushDB(unusedContext).Err()
+}

--- a/stats_test.go
+++ b/stats_test.go
@@ -9,14 +9,15 @@ import (
 )
 
 func TestStats(t *testing.T) {
-	connection, err := OpenConnection("stats-conn", "tcp", "localhost:6379", 1, nil)
+
+	connection, err := OpenConnection("stats-conn", sOp, nil)
 	assert.NoError(t, err)
 	_, err = NewCleaner(connection).Clean()
 	require.NoError(t, err)
 
-	conn1, err := OpenConnection("stats-conn1", "tcp", "localhost:6379", 1, nil)
+	conn1, err := OpenConnection("stats-conn1", sOp, nil)
 	assert.NoError(t, err)
-	conn2, err := OpenConnection("stats-conn2", "tcp", "localhost:6379", 1, nil)
+	conn2, err := OpenConnection("stats-conn2", sOp, nil)
 	assert.NoError(t, err)
 	q1, err := conn2.OpenQueue("stats-q1")
 	assert.NoError(t, err)


### PR DESCRIPTION
Hi team,
Thanks to the authors to provide such a nice and effective rmq for Gophers!

I'm using this packge and have to work with a redis cluster, so I forked and added a new RedisClusterWrapper for the cluster to fit in.

- NewWrapper for cluster
- Rename original wrapper as SingleWrapper also the filename
- Open redis connection with `*redis.Option` which could allow users to connect their redis more freely
- Added/modified some tests roughly for the cluster testing.

Please feel free to modify/update these commits

====================
And a big thanks to ISSUE #113 , @obh provided a direction to the cluster path

Best,
David