### PR TITLE
Add support for header transferring

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,15 @@ for example with [`propagation.HeaderCarrier`](https://pkg.go.dev/go.opentelemet
  })
 ```
 
+Adding a header is an explicit opt-in operation and so it does not affect library's
+backwards compatibility by default (when not used). 
+
+Please note that adding header may lead to compatibility issues if:
+* consumer is built with older version of `rmq` when publisher has already 
+   started using header, this can be avoided by upgrading consumers before publishers;
+* consumer is not using `rmq` (other libs, low level tools like `redis-cli`) and is 
+   not aware of payload format extension.
+
 ## Testing Included
 
 To simplify testing of queue producers and consumers we include test mocks.

--- a/README.md
+++ b/README.md
@@ -473,14 +473,14 @@ See [`example/cleaner`][cleaner.go].
 
 [cleaner.go]: example/cleaner/main.go
 
-### Headers
+### Header
 
-Redis protocol does not define a specific way to pass additional data like headers.
+Redis protocol does not define a specific way to pass additional data like header.
 However, there is often need to pass them (for example for traces propagation).
 
 This implementation injects optional header values marked with a signature into 
 payload body during publishing. When message is consumed, if signature is present, 
-headers and original payload are extracted from augmented payload.
+header and original payload are extracted from augmented payload.
 
 Header is defined as `http.Header` for better interoperability with existing libraries,
 for example with [`propagation.HeaderCarrier`](https://pkg.go.dev/go.opentelemetry.io/otel/propagation#HeaderCarrier).
@@ -492,7 +492,7 @@ for example with [`propagation.HeaderCarrier`](https://pkg.go.dev/go.opentelemet
  h.Set("X-Baz", "quux")
 
  // You can add header to your payload during publish.
- _ = pub.Publish(rmq.PayloadWithHeaders(`{"foo":"bar"}`, h))
+ _ = pub.Publish(rmq.PayloadWithHeader(`{"foo":"bar"}`, h))
 
  // ....
 

--- a/README.md
+++ b/README.md
@@ -476,13 +476,13 @@ See [`example/cleaner`][cleaner.go].
 ### Headers
 
 Redis protocol does not define a specific way to pass additional data like headers.
-However, there is often need to pass then (for example for traces propagation).
+However, there is often need to pass them (for example for traces propagation).
 
 This implementation injects optional header values marked with a signature into 
 payload body during publishing. When message is consumed, if signature is present, 
 headers and original payload are extracted from augmented payload.
 
-Header is defined as http.Header for better interoperability with existing libraries,
+Header is defined as `http.Header` for better interoperability with existing libraries,
 for example with [`propagation.HeaderCarrier`](https://pkg.go.dev/go.opentelemetry.io/otel/propagation#HeaderCarrier).
 
 ```go

--- a/header.go
+++ b/header.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Redis protocol does not define a specific way to pass additional data like headers.
-// However, there is often need to pass then (for example for traces propagation).
+// However, there is often need to pass them (for example for traces propagation).
 //
 // This implementation injects optional header values marked with a signature into payload body
 // during publishing. When message is consumed, if signature is present, headers and original payload

--- a/header.go
+++ b/header.go
@@ -1,0 +1,79 @@
+package rmq
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// Redis protocol does not define a specific way to pass additional data like headers.
+// However, there is often need to pass then (for example for traces propagation).
+//
+// This implementation injects optional header values marked with a signature into payload body
+// during publishing. When message is consumed, if signature is present, headers and original payload
+// are extracted from augmented payload.
+//
+// Header is defined as http.Header for better interoperability with existing libraries,
+// for example with go.opentelemetry.io/otel/propagation.HeaderCarrier.
+
+// PayloadWithHeaders creates a payload string with header.
+func PayloadWithHeaders(payload string, header http.Header) string {
+	if len(header) == 0 {
+		return payload
+	}
+
+	hd, _ := json.Marshal(header) // String map never fails marshaling.
+
+	return jsonHeaderSignature + string(hd) + "\n" + payload
+}
+
+// PayloadBytesWithHeaders creates payload bytes slice with header.
+func PayloadBytesWithHeaders(payload []byte, header http.Header) []byte {
+	if len(header) == 0 {
+		return payload
+	}
+
+	hd, _ := json.Marshal(header) // String map never fails marshaling.
+
+	res := make([]byte, 0, len(jsonHeaderSignature)+len(hd)+1+len(payload))
+	res = append(res, []byte(jsonHeaderSignature)...)
+	res = append(res, hd...)
+	res = append(res, '\n')
+	res = append(res, payload...)
+
+	return res
+}
+
+// ExtractHeaderAndPayload splits augmented payload into header and original payload if specific signature is present.
+func ExtractHeaderAndPayload(payload string) (http.Header, string, error) {
+	if !strings.HasPrefix(payload, jsonHeaderSignature) {
+		return nil, payload, nil
+	}
+
+	lineEnd := strings.Index(payload, "\n")
+	if lineEnd == -1 {
+		return nil, "", errors.New("missing line separator")
+	}
+
+	first := payload[len(jsonHeaderSignature):lineEnd]
+	rest := payload[lineEnd+1:]
+
+	headers := make(http.Header)
+
+	if err := json.Unmarshal([]byte(first), &headers); err != nil {
+		return nil, "", fmt.Errorf("parsing header: %w", err)
+	}
+
+	return headers, rest, nil
+}
+
+// WithHeader is a Delivery with Header.
+type WithHeader interface {
+	Header() http.Header
+}
+
+// jsonHeaderSignature is a signature marker to indicate JSON header presence.
+// Do not change the value.
+const jsonHeaderSignature = "\xFF\x00\xBE\xBEJ"

--- a/header.go
+++ b/header.go
@@ -8,18 +8,18 @@ import (
 	"strings"
 )
 
-// Redis protocol does not define a specific way to pass additional data like headers.
+// Redis protocol does not define a specific way to pass additional data like header.
 // However, there is often need to pass them (for example for traces propagation).
 //
 // This implementation injects optional header values marked with a signature into payload body
-// during publishing. When message is consumed, if signature is present, headers and original payload
+// during publishing. When message is consumed, if signature is present, header and original payload
 // are extracted from augmented payload.
 //
 // Header is defined as http.Header for better interoperability with existing libraries,
 // for example with go.opentelemetry.io/otel/propagation.HeaderCarrier.
 
-// PayloadWithHeaders creates a payload string with header.
-func PayloadWithHeaders(payload string, header http.Header) string {
+// PayloadWithHeader creates a payload string with header.
+func PayloadWithHeader(payload string, header http.Header) string {
 	if len(header) == 0 {
 		return payload
 	}
@@ -29,8 +29,8 @@ func PayloadWithHeaders(payload string, header http.Header) string {
 	return jsonHeaderSignature + string(hd) + "\n" + payload
 }
 
-// PayloadBytesWithHeaders creates payload bytes slice with header.
-func PayloadBytesWithHeaders(payload []byte, header http.Header) []byte {
+// PayloadBytesWithHeader creates payload bytes slice with header.
+func PayloadBytesWithHeader(payload []byte, header http.Header) []byte {
 	if len(header) == 0 {
 		return payload
 	}
@@ -60,13 +60,13 @@ func ExtractHeaderAndPayload(payload string) (http.Header, string, error) {
 	first := payload[len(jsonHeaderSignature):lineEnd]
 	rest := payload[lineEnd+1:]
 
-	headers := make(http.Header)
+	header := make(http.Header)
 
-	if err := json.Unmarshal([]byte(first), &headers); err != nil {
+	if err := json.Unmarshal([]byte(first), &header); err != nil {
 		return nil, "", fmt.Errorf("parsing header: %w", err)
 	}
 
-	return headers, rest, nil
+	return header, rest, nil
 }
 
 // WithHeader is a Delivery with Header.

--- a/header_test.go
+++ b/header_test.go
@@ -78,6 +78,14 @@ func TestExtractHeaderAndPayload(t *testing.T) {
 		assert.Equal(t, http.Header{"foo": []string{"bar"}}, h)
 		assert.Equal(t, "foo", p)
 	})
+
+	t.Run("ok_line_breaks", func(t *testing.T) {
+		ph := rmq.PayloadWithHeader("foo", http.Header{"foo": []string{"bar1\nbar2\nbar3"}})
+		h, p, err := rmq.ExtractHeaderAndPayload(ph)
+		require.NoError(t, err)
+		assert.Equal(t, http.Header{"foo": []string{"bar1\nbar2\nbar3"}}, h)
+		assert.Equal(t, "foo", p)
+	})
 }
 
 func ExamplePayloadWithHeader() {

--- a/header_test.go
+++ b/header_test.go
@@ -1,19 +1,20 @@
 package rmq_test
 
 import (
-	"github.com/adjust/rmq/v5"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/adjust/rmq/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestPayloadWithHeaders(t *testing.T) {
+func TestPayloadWithHeader(t *testing.T) {
 	p := `{"foo":"bar"}`
 
 	h := make(http.Header)
-	ph := rmq.PayloadWithHeaders(p, h)
+	ph := rmq.PayloadWithHeader(p, h)
 	assert.Equal(t, p, ph) // No change for empty header.
 	h2, p2, err := rmq.ExtractHeaderAndPayload(ph)
 	require.NoError(t, err)
@@ -21,7 +22,7 @@ func TestPayloadWithHeaders(t *testing.T) {
 	assert.Equal(t, p, p2)
 
 	h.Set("X-Foo", "Bar")
-	ph = rmq.PayloadWithHeaders(p, h)
+	ph = rmq.PayloadWithHeader(p, h)
 	assert.NotEqual(t, p, ph)
 
 	h2, p2, err = rmq.ExtractHeaderAndPayload(ph)
@@ -30,11 +31,11 @@ func TestPayloadWithHeaders(t *testing.T) {
 	assert.Equal(t, p, p2)
 }
 
-func TestPayloadBytesWithHeaders(t *testing.T) {
+func TestPayloadBytesWithHeader(t *testing.T) {
 	p := `{"foo":"bar"}`
 
 	h := make(http.Header)
-	ph := rmq.PayloadBytesWithHeaders([]byte(p), h)
+	ph := rmq.PayloadBytesWithHeader([]byte(p), h)
 	assert.Equal(t, p, string(ph)) // No change for empty header.
 	h2, p2, err := rmq.ExtractHeaderAndPayload(string(ph))
 	require.NoError(t, err)
@@ -42,7 +43,7 @@ func TestPayloadBytesWithHeaders(t *testing.T) {
 	assert.Equal(t, p, p2)
 
 	h.Set("X-Foo", "Bar")
-	ph = rmq.PayloadBytesWithHeaders([]byte(p), h)
+	ph = rmq.PayloadBytesWithHeader([]byte(p), h)
 	assert.NotEqual(t, p, ph)
 
 	h2, p2, err = rmq.ExtractHeaderAndPayload(string(ph))
@@ -53,7 +54,7 @@ func TestPayloadBytesWithHeaders(t *testing.T) {
 
 func TestExtractHeaderAndPayload(t *testing.T) {
 	t.Run("missing_line_separator", func(t *testing.T) {
-		ph := rmq.PayloadWithHeaders("foo", http.Header{"foo": []string{"bar"}})
+		ph := rmq.PayloadWithHeader("foo", http.Header{"foo": []string{"bar"}})
 		ph = ph[0:7] // Truncating payload.
 		h, p, err := rmq.ExtractHeaderAndPayload(ph)
 		require.Error(t, err)
@@ -62,7 +63,7 @@ func TestExtractHeaderAndPayload(t *testing.T) {
 	})
 
 	t.Run("invalid_json", func(t *testing.T) {
-		ph := rmq.PayloadWithHeaders("foo", http.Header{"foo": []string{"bar"}})
+		ph := rmq.PayloadWithHeader("foo", http.Header{"foo": []string{"bar"}})
 		ph = strings.Replace(ph, `"`, `'`, 1) // Corrupting JSON.
 		h, p, err := rmq.ExtractHeaderAndPayload(ph)
 		require.Error(t, err)
@@ -71,7 +72,7 @@ func TestExtractHeaderAndPayload(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		ph := rmq.PayloadWithHeaders("foo", http.Header{"foo": []string{"bar"}})
+		ph := rmq.PayloadWithHeader("foo", http.Header{"foo": []string{"bar"}})
 		h, p, err := rmq.ExtractHeaderAndPayload(ph)
 		require.NoError(t, err)
 		assert.Equal(t, http.Header{"foo": []string{"bar"}}, h)
@@ -79,7 +80,7 @@ func TestExtractHeaderAndPayload(t *testing.T) {
 	})
 }
 
-func ExamplePayloadWithHeaders() {
+func ExamplePayloadWithHeader() {
 	var (
 		pub, con rmq.Queue
 	)
@@ -90,7 +91,7 @@ func ExamplePayloadWithHeaders() {
 	h.Set("X-Baz", "quux")
 
 	// You can add header to your payload during publish.
-	_ = pub.Publish(rmq.PayloadWithHeaders(`{"foo":"bar"}`, h))
+	_ = pub.Publish(rmq.PayloadWithHeader(`{"foo":"bar"}`, h))
 
 	// ....
 

--- a/header_test.go
+++ b/header_test.go
@@ -1,0 +1,103 @@
+package rmq_test
+
+import (
+	"github.com/adjust/rmq/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestPayloadWithHeaders(t *testing.T) {
+	p := `{"foo":"bar"}`
+
+	h := make(http.Header)
+	ph := rmq.PayloadWithHeaders(p, h)
+	assert.Equal(t, p, ph) // No change for empty header.
+	h2, p2, err := rmq.ExtractHeaderAndPayload(ph)
+	require.NoError(t, err)
+	assert.Nil(t, h2)
+	assert.Equal(t, p, p2)
+
+	h.Set("X-Foo", "Bar")
+	ph = rmq.PayloadWithHeaders(p, h)
+	assert.NotEqual(t, p, ph)
+
+	h2, p2, err = rmq.ExtractHeaderAndPayload(ph)
+	require.NoError(t, err)
+	assert.Equal(t, h, h2)
+	assert.Equal(t, p, p2)
+}
+
+func TestPayloadBytesWithHeaders(t *testing.T) {
+	p := `{"foo":"bar"}`
+
+	h := make(http.Header)
+	ph := rmq.PayloadBytesWithHeaders([]byte(p), h)
+	assert.Equal(t, p, string(ph)) // No change for empty header.
+	h2, p2, err := rmq.ExtractHeaderAndPayload(string(ph))
+	require.NoError(t, err)
+	assert.Nil(t, h2)
+	assert.Equal(t, p, p2)
+
+	h.Set("X-Foo", "Bar")
+	ph = rmq.PayloadBytesWithHeaders([]byte(p), h)
+	assert.NotEqual(t, p, ph)
+
+	h2, p2, err = rmq.ExtractHeaderAndPayload(string(ph))
+	require.NoError(t, err)
+	assert.Equal(t, h, h2)
+	assert.Equal(t, p, string(p2))
+}
+
+func TestExtractHeaderAndPayload(t *testing.T) {
+	t.Run("missing_line_separator", func(t *testing.T) {
+		ph := rmq.PayloadWithHeaders("foo", http.Header{"foo": []string{"bar"}})
+		ph = ph[0:7] // Truncating payload.
+		h, p, err := rmq.ExtractHeaderAndPayload(ph)
+		require.Error(t, err)
+		assert.Nil(t, h)
+		assert.Empty(t, p)
+	})
+
+	t.Run("invalid_json", func(t *testing.T) {
+		ph := rmq.PayloadWithHeaders("foo", http.Header{"foo": []string{"bar"}})
+		ph = strings.Replace(ph, `"`, `'`, 1) // Corrupting JSON.
+		h, p, err := rmq.ExtractHeaderAndPayload(ph)
+		require.Error(t, err)
+		assert.Nil(t, h)
+		assert.Empty(t, p)
+	})
+
+	t.Run("ok", func(t *testing.T) {
+		ph := rmq.PayloadWithHeaders("foo", http.Header{"foo": []string{"bar"}})
+		h, p, err := rmq.ExtractHeaderAndPayload(ph)
+		require.NoError(t, err)
+		assert.Equal(t, http.Header{"foo": []string{"bar"}}, h)
+		assert.Equal(t, "foo", p)
+	})
+}
+
+func ExamplePayloadWithHeaders() {
+	var (
+		pub, con rmq.Queue
+	)
+
+	// ....
+
+	h := make(http.Header)
+	h.Set("X-Baz", "quux")
+
+	// You can add header to your payload during publish.
+	_ = pub.Publish(rmq.PayloadWithHeaders(`{"foo":"bar"}`, h))
+
+	// ....
+
+	_, _ = con.AddConsumerFunc("tag", func(delivery rmq.Delivery) {
+		// And receive header back in consumer.
+		delivery.(rmq.WithHeader).Header().Get("X-Baz") // "quux"
+
+		// ....
+	})
+}

--- a/queue.go
+++ b/queue.go
@@ -216,13 +216,18 @@ func (queue *redisQueue) consumeBatch() error {
 			return err
 		}
 
-		queue.deliveryChan <- queue.newDelivery(payload)
+		d, err := queue.newDelivery(payload)
+		if err != nil {
+			return err
+		}
+
+		queue.deliveryChan <- d
 	}
 
 	return nil
 }
 
-func (queue *redisQueue) newDelivery(payload string) Delivery {
+func (queue *redisQueue) newDelivery(payload string) (Delivery, error) {
 	return newDelivery(
 		queue.ackCtx,
 		payload,

--- a/queue_test.go
+++ b/queue_test.go
@@ -877,7 +877,7 @@ func TestQueueHeader(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.NoError(t, queue.Publish("queue-d1"))
-	assert.NoError(t, queue.Publish(PayloadWithHeaders("queue-d2", http.Header{"X-Foo": []string{"d2"}})))
+	assert.NoError(t, queue.Publish(PayloadWithHeader("queue-d2", http.Header{"X-Foo": []string{"d2"}})))
 
 	assert.Eventually(t, func() bool {
 		return atomic.LoadInt64(&consumed) == 2

--- a/queue_test.go
+++ b/queue_test.go
@@ -3,7 +3,9 @@ package rmq
 import (
 	"fmt"
 	"math"
+	"net/http"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -832,4 +834,55 @@ func TestQueueDrain(t *testing.T) {
 		assert.Equal(t, 10, len(values))
 		eventuallyReady(t, queue, int64(100-x*10))
 	}
+}
+
+func TestQueueHeader(t *testing.T) {
+	redisAddr, closer := testRedis(t)
+	defer closer()
+
+	connection, err := OpenConnection("queue-h-conn", "tcp", redisAddr, 1, nil)
+	assert.NoError(t, err)
+	require.NotNil(t, connection)
+
+	queue, err := connection.OpenQueue("queue-h")
+	assert.NoError(t, err)
+	require.NotNil(t, queue)
+	_, err = queue.PurgeReady()
+	assert.NoError(t, err)
+
+	assert.NoError(t, queue.StartConsuming(2, time.Millisecond))
+	time.Sleep(time.Millisecond)
+	assert.NoError(t, err)
+
+	consumed := int64(0)
+	cons := ConsumerFunc(func(delivery Delivery) {
+		atomic.AddInt64(&consumed, 1)
+
+		h, ok := delivery.(WithHeader)
+		assert.True(t, ok)
+
+		switch delivery.Payload() {
+		case "queue-d1":
+			assert.Empty(t, h.Header())
+		case "queue-d2":
+			require.NotNil(t, h.Header())
+			assert.Equal(t, "d2", h.Header().Get("X-Foo"))
+		default:
+			assert.Failf(t, "unexpected payload: %q", delivery.Payload())
+		}
+
+	})
+
+	_, err = queue.AddConsumer("queue-cons1", cons)
+	assert.NoError(t, err)
+
+	assert.NoError(t, queue.Publish("queue-d1"))
+	assert.NoError(t, queue.Publish(PayloadWithHeaders("queue-d2", http.Header{"X-Foo": []string{"d2"}})))
+
+	assert.Eventually(t, func() bool {
+		return atomic.LoadInt64(&consumed) == 2
+	}, 10*time.Second, time.Millisecond)
+
+	<-queue.StopConsuming()
+	assert.NoError(t, connection.stopHeartbeat())
 }


### PR DESCRIPTION
Redis protocol does not define a specific way to pass additional data like header.
However, there is often need to pass them (for example for traces propagation).

This implementation injects optional header values marked with a signature into 
payload body during publishing. When message is consumed, if signature is present, 
header and original payload are extracted from augmented payload.

Header is defined as `http.Header` for better interoperability with existing libraries,
for example with [`propagation.HeaderCarrier`](https://pkg.go.dev/go.opentelemetry.io/otel/propagation#HeaderCarrier).

```go
 // ....
 
 h := make(http.Header)
 h.Set("X-Baz", "quux")

 // You can add header to your payload during publish.
 _ = pub.Publish(rmq.PayloadWithHeader(`{"foo":"bar"}`, h))

 // ....

 _, _ = con.AddConsumerFunc("tag", func(delivery rmq.Delivery) {
     // And receive header back in consumer.
     delivery.(rmq.WithHeader).Header().Get("X-Baz") // "quux"
     
     // ....
 })
```

This change is intended to be backwards compatible.

Header parsing is only done if payload starts with `"\xFF\x00\xBE\xBEJ"`, such signature is added along with header values explicitly by caller during publishing (using `PayloadWithHeader` helper).