### PR TITLE
reject a faulty delivery logic

### DIFF
--- a/delivery.go
+++ b/delivery.go
@@ -36,34 +36,6 @@ func (delivery *redisDelivery) Header() http.Header {
 	return delivery.header
 }
 
-func newDelivery(
-	ctx context.Context,
-	payload string,
-	unackedKey string,
-	rejectedKey string,
-	pushKey string,
-	redisClient RedisClient,
-	errChan chan<- error,
-) (*redisDelivery, error) {
-	rd := redisDelivery{
-		ctx:         ctx,
-		payload:     payload,
-		unackedKey:  unackedKey,
-		rejectedKey: rejectedKey,
-		pushKey:     pushKey,
-		redisClient: redisClient,
-		errChan:     errChan,
-	}
-
-	var err error
-
-	if rd.header, rd.clearPayload, err = ExtractHeaderAndPayload(payload); err != nil {
-		return nil, err
-	}
-
-	return &rd, nil
-}
-
 func (delivery *redisDelivery) String() string {
 	return fmt.Sprintf("[%s %s]", delivery.clearPayload, delivery.unackedKey)
 }

--- a/queue.go
+++ b/queue.go
@@ -219,7 +219,7 @@ func (queue *redisQueue) consumeBatch() error {
 
 		d, err := queue.newDelivery(payload)
 		if err != nil {
-			return err
+			return fmt.Errorf("create new delivery: %w", err)
 		}
 
 		queue.deliveryChan <- d
@@ -229,15 +229,28 @@ func (queue *redisQueue) consumeBatch() error {
 }
 
 func (queue *redisQueue) newDelivery(payload string) (Delivery, error) {
-	return newDelivery(
-		queue.ackCtx,
-		payload,
-		queue.unackedKey,
-		queue.rejectedKey,
-		queue.pushKey,
-		queue.redisClient,
-		queue.errChan,
-	)
+	rd := &redisDelivery{
+		ctx:         queue.ackCtx,
+		payload:     payload,
+		unackedKey:  queue.unackedKey,
+		rejectedKey: queue.rejectedKey,
+		pushKey:     queue.pushKey,
+		redisClient: queue.redisClient,
+		errChan:     queue.errChan,
+	}
+
+	var err error
+	rd.header, rd.clearPayload, err = ExtractHeaderAndPayload(payload)
+	if err == nil {
+		return rd, nil
+	}
+
+	rejectErr := rd.Reject()
+	if err != nil {
+		return nil, fmt.Errorf("%s, reject faulty delivery: %w", err, rejectErr)
+	}
+
+	return nil, err
 }
 
 // StopConsuming can be used to stop all consumers on this queue. It returns a

--- a/queue.go
+++ b/queue.go
@@ -212,7 +212,6 @@ func (queue *redisQueue) consumeBatch() error {
 		if err == ErrorNotFound {
 			return nil
 		}
-
 		if err != nil {
 			return err
 		}
@@ -245,6 +244,7 @@ func (queue *redisQueue) newDelivery(payload string) (Delivery, error) {
 		return rd, nil
 	}
 
+	// we need to reject a delivery here to move the delivery from the unacked to the rejected list.
 	rejectErr := rd.Reject()
 	if err != nil {
 		return nil, fmt.Errorf("%s, reject faulty delivery: %w", err, rejectErr)

--- a/queue.go
+++ b/queue.go
@@ -246,7 +246,7 @@ func (queue *redisQueue) newDelivery(payload string) (Delivery, error) {
 
 	// we need to reject a delivery here to move the delivery from the unacked to the rejected list.
 	rejectErr := rd.Reject()
-	if err != nil {
+	if rejectErr != nil {
 		return nil, fmt.Errorf("%s, reject faulty delivery: %w", err, rejectErr)
 	}
 


### PR DESCRIPTION
Messages with broken headers (for example, without a separator) has never been rejected and stayed forever in unack. 
This PR fixes the bug. If there is an error creating a delivery, we will reject it. 