### PR TITLE
142 Stop Heartbeat StopAllConsuming()

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,9 @@ use case where you actually need that sort of flexibility, please let us know.
 Currently for each queue you are only supposed to call `StartConsuming()` and
 `StopConsuming()` at most once.
 
+Also note that `StopAllConsuming()` will stop the heartbeat for this connection.
+It's advised to also not publish to any queue opened by this connection anymore.
+
 ### Return Rejected Deliveries
 
 Even if you don't have a push queue setup there are cases where you need to

--- a/errors.go
+++ b/errors.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	ErrorNotFound         = errors.New("entity not found") // entitify being connection/queue/delivery
+	ErrorNotFound         = errors.New("entity not found") // entity being connection/queue/delivery/heartbeat
 	ErrorAlreadyConsuming = errors.New("must not call StartConsuming() multiple times")
 	ErrorNotConsuming     = errors.New("must call StartConsuming() before adding consumers")
 	ErrorConsumingStopped = errors.New("consuming stopped")


### PR DESCRIPTION
> Once all consumers of the connection have been stopped we also stop the heartbeat goroutine to avoid a goroutine leak.

Close #142. Also related to #149.