### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ payload to a queue:
 
 ```go
 delivery := "task payload"
-err := TaskQueue.Publish(delivery)
+err := taskQueue.Publish(delivery)
 ```
 
 In practice, however, it's more common to have instances of some struct that we


### PR DESCRIPTION
change `TaskQueue` to `taskQueue` for better consistency. Because the first time I read I was wondering where did the `TaskQueue` come from, then I realize that it's the `taskQueue` just created previous lines.