### PR TITLE
Use actions/cache@v3 in github workflows

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -48,7 +48,7 @@ jobs:
           ref: ${{ (github.event.inputs.new != '') && github.event.inputs.new || github.event.ref }}
 
       - name: Go cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           # In order:
           # * Module download cache
@@ -61,7 +61,7 @@ jobs:
             ${{ runner.os }}-go-cache
 
       - name: Restore benchstat
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/go/bin/benchstat
           key: ${{ runner.os }}-benchstat-legacy
@@ -69,7 +69,7 @@ jobs:
       - name: Restore base benchmark result
         id: base-benchmark
         if: env.CACHE_BENCHMARK == 'on'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             bench-master.txt

--- a/.github/workflows/gorelease.yml
+++ b/.github/workflows/gorelease.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Gorelease cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/go/bin/gorelease

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Go cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           # In order:
           # * Module download cache
@@ -51,7 +51,7 @@ jobs:
       - name: Restore base test coverage
         id: base-coverage
         if: matrix.go-version == env.COV_GO_VERSION && github.event.pull_request.base.sha != ''
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             unit-base.txt


### PR DESCRIPTION
v2 is going to be deprecated in February 2025.